### PR TITLE
Update prompting strategy to remove placeholder content

### DIFF
--- a/Example_1.md
+++ b/Example_1.md
@@ -1,1265 +1,860 @@
 # The Basics of Large Language Models
 
-## What are Large Language Models?
-**What are Large Language Models?: Overview of Large Language Models and their Importance**
-
-In recent years, the field of Natural Language Processing (NLP) has witnessed a significant breakthrough with the development of Large Language Models (LLMs). These models have revolutionized the way we interact with language, enabling machines to understand and generate human-like text with unprecedented accuracy. In this chapter, we will delve into the world of LLMs, exploring their definition, architecture, and importance in various applications.
-
-**What are Large Language Models?**
-
-Large Language Models are artificial intelligence (AI) models trained on vast amounts of text data to learn patterns, relationships, and structures within language. These models are designed to process and generate human language, mimicking the way humans communicate. LLMs are typically trained on massive datasets, comprising billions of words, to learn the intricacies of language, including grammar, syntax, and semantics.
-
-**Architecture of Large Language Models**
-
-Large Language Models are typically based on transformer architectures, which were introduced in the paper "Attention Is All You Need" by Vaswani et al. in 2017. The transformer architecture is particularly well-suited for NLP tasks due to its ability to model long-range dependencies and parallelize the computation process.
-
-The basic components of a transformer-based LLM include:
-
-1. **Encoder**: The encoder is responsible for processing the input text, breaking it down into a sequence of tokens, and generating a continuous representation of the input.
-2. **Decoder**: The decoder takes the output from the encoder and generates the output text, one token at a time.
-3. **Self-Attention Mechanism**: This mechanism allows the model to focus on specific parts of the input text, enabling it to model complex relationships between words and phrases.
-4. **Positional Encoding**: This technique is used to incorporate positional information into the model, allowing it to understand the context and relationships between words.
-
-**Importance of Large Language Models**
-
-Large Language Models have far-reaching implications across various industries and applications. Some of the key importance of LLMs includes:
-
-1. **Language Translation**: LLMs can be fine-tuned for machine translation tasks, enabling accurate and efficient translation of languages.
-2. **Text Summarization**: LLMs can be used to summarize long documents, extracting key information and condensing it into a concise summary.
-3. **Sentiment Analysis**: LLMs can analyze text to determine the sentiment, tone, and emotions expressed in the text.
-4. **Question Answering**: LLMs can be used to answer questions, providing accurate and relevant information.
-5. **Content Generation**: LLMs can generate high-quality content, such as articles, blog posts, and social media posts.
-6. **Chatbots and Virtual Assistants**: LLMs can be integrated into chatbots and virtual assistants, enabling more human-like conversations.
-7. **Research and Academia**: LLMs have the potential to revolutionize research in NLP, enabling the development of new models, techniques, and applications.
-
-**Challenges and Limitations**
-
-While Large Language Models have achieved remarkable success, they are not without their challenges and limitations. Some of the key challenges include:
-
-1. **Data Quality**: The quality of the training data is critical to the performance of the model. Poor-quality data can lead to biased or inaccurate results.
-2. **Explainability**: LLMs are often opaque, making it difficult to understand the reasoning behind their decisions.
-3. **Adversarial Attacks**: LLMs can be vulnerable to adversarial attacks, which can compromise their performance.
-4. **Fairness and Bias**: LLMs can perpetuate biases present in the training data, highlighting the need for careful consideration of fairness and bias in model development.
-
-**Conclusion**
-
-Large Language Models have the potential to transform the way we interact with language, enabling machines to understand and generate human-like text with unprecedented accuracy. As the field of NLP continues to evolve, it is essential to address the challenges and limitations of LLMs, ensuring that these models are developed and deployed responsibly. By understanding the importance and implications of LLMs, we can unlock new possibilities for human-computer interaction, research, and innovation.
-
-## Why Study Large Language Models?
-**Why Study Large Language Models?: Importance of Understanding Large Language Models in Today's World**
-
-In today's digital age, language has become an integral part of our daily lives. With the rapid advancements in artificial intelligence and machine learning, large language models have emerged as a crucial component of modern technology. These models have revolutionized the way we interact with machines, process information, and communicate with each other. In this chapter, we will delve into the importance of understanding large language models and their significance in today's world.
-
-**What are Large Language Models?**
-
-Before we dive into the importance of large language models, it is essential to understand what they are. Large language models are artificial intelligence (AI) models that are trained on vast amounts of text data to generate human-like language. These models are designed to process and understand natural language, enabling them to perform tasks such as language translation, text summarization, and sentiment analysis.
-
-**The Rise of Large Language Models**
-
-The development of large language models has been a significant milestone in the field of natural language processing (NLP). The first large language model was introduced in the 2010s, and since then, there has been an explosion of research and development in this area. The rise of large language models can be attributed to the advancements in computing power, data storage, and machine learning algorithms.
-
-**Why are Large Language Models Important?**
-
-Large language models are important for several reasons:
-
-1. **Improved Language Understanding**: Large language models have the ability to understand human language, enabling them to process and analyze vast amounts of text data. This has significant implications for various industries, including healthcare, finance, and education.
-2. **Enhanced Customer Experience**: Large language models can be used to create chatbots and virtual assistants that can understand and respond to customer queries, providing a more personalized and efficient customer experience.
-3. **Increased Efficiency**: Large language models can automate tasks such as data entry, document processing, and content creation, freeing up human resources for more strategic and creative tasks.
-4. **Improved Decision-Making**: Large language models can analyze vast amounts of text data to provide insights and recommendations, enabling businesses to make more informed decisions.
-5. **Enhanced Accessibility**: Large language models can be used to create accessible language tools for people with disabilities, such as text-to-speech systems and speech-to-text systems.
-
-**Challenges and Limitations of Large Language Models**
-
-While large language models have revolutionized the way we interact with machines, they are not without their challenges and limitations. Some of the key challenges include:
-
-1. **Bias and Fairness**: Large language models can perpetuate biases and unfairness, particularly if they are trained on biased data.
-2. **Data Quality**: The quality of the data used to train large language models can significantly impact their performance and accuracy.
-3. **Explainability**: Large language models can be difficult to explain and interpret, making it challenging to understand their decision-making processes.
-4. **Security**: Large language models can be vulnerable to attacks and exploitation, particularly if they are not properly secured.
-
-**Conclusion**
-
-In conclusion, large language models are a crucial component of modern technology, enabling us to interact with machines in a more natural and intuitive way. While they have significant implications for various industries and applications, they also present challenges and limitations that must be addressed. As we continue to develop and refine large language models, it is essential that we prioritize fairness, explainability, and security to ensure that these models are used responsibly and ethically.
-
-**Recommendations for Future Research**
-
-1. **Improved Data Quality**: Future research should focus on improving the quality of the data used to train large language models, ensuring that they are fair, unbiased, and representative of the population.
-2. **Explainability and Transparency**: Researchers should prioritize the development of explainable and transparent large language models, enabling us to understand their decision-making processes and biases.
-3. **Security and Privacy**: Future research should focus on securing and protecting large language models from attacks and exploitation, ensuring that they are used responsibly and ethically.
-4. **Human-AI Collaboration**: Researchers should explore the potential for human-AI collaboration, enabling humans and machines to work together more effectively and efficiently.
-
-By understanding the importance of large language models and addressing the challenges and limitations associated with them, we can unlock their full potential and create a more efficient, accessible, and equitable future.
-
-### What is a Language Model?
-**Chapter 1: What is a Language Model?: Definition and Explanation**
-
-Language models have revolutionized the field of natural language processing (NLP) in recent years, enabling machines to understand, generate, and interact with human language in ways that were previously unimaginable. But what exactly is a language model, and how does it work? In this chapter, we'll delve into the definition and explanation of language models, exploring their history, components, and applications.
-
-**Definition**
-
-A language model is a type of artificial intelligence (AI) system designed to process and generate human language. It's a statistical model that predicts the likelihood of a sequence of words or characters, given the context and the language's grammar and syntax. In other words, a language model is a machine learning algorithm that learns to recognize patterns in language, allowing it to generate coherent and meaningful text.
-
-**History of Language Models**
-
-The concept of language models dates back to the 1950s, when the first computer programs were developed to analyze and generate human language. However, it wasn't until the 1990s that language models began to gain popularity, with the introduction of probabilistic language models. These early models were based on statistical techniques, such as n-grams and Markov chains, which analyzed the frequency of word sequences to predict the likelihood of a word given its context.
-
-The 2010s saw a significant breakthrough in language modeling with the development of recurrent neural networks (RNNs) and long short-term memory (LSTM) networks. These architectures enabled language models to capture long-range dependencies and contextual relationships in language, leading to significant improvements in language understanding and generation.
-
-**Components of a Language Model**
-
-A language model typically consists of three main components:
-
-1. **Input Representation**: This component converts the input text into a numerical representation that can be processed by the model. This may involve tokenization, stemming, or lemmatization to normalize the text and reduce its dimensionality.
-2. **Encoder**: The encoder is responsible for processing the input representation and generating a contextualized representation of the input text. This may involve techniques such as attention mechanisms, which allow the model to focus on specific parts of the input text.
-3. **Decoder**: The decoder takes the contextualized representation generated by the encoder and generates the output text. This may involve techniques such as beam search or sampling to generate the output text.
-
-**Types of Language Models**
-
-There are several types of language models, each with its strengths and weaknesses:
-
-1. **Statistical Language Models**: These models are based on statistical techniques, such as n-grams and Markov chains, to analyze the frequency of word sequences.
-2. **Neural Language Models**: These models use neural networks, such as RNNs and LSTMs, to capture long-range dependencies and contextual relationships in language.
-3. **Transformers**: These models use self-attention mechanisms to process input sequences and generate output text.
-
-**Applications of Language Models**
-
-Language models have numerous applications in NLP, including:
-
-1. **Language Translation**: Language models can be used to translate text from one language to another.
-2. **Text Summarization**: Language models can be used to summarize long pieces of text into shorter, more digestible versions.
-3. **Chatbots and Virtual Assistants**: Language models can be used to power chatbots and virtual assistants, enabling them to understand and respond to user queries.
-4. **Content Generation**: Language models can be used to generate content, such as articles, blog posts, and social media updates.
-
-**Conclusion**
-
-In conclusion, language models have revolutionized the field of NLP, enabling machines to understand, generate, and interact with human language in ways that were previously unimaginable. By understanding the definition, components, and applications of language models, we can better appreciate the potential and limitations of these powerful tools. In the next chapter, we'll explore the challenges and limitations of language models, as well as the future directions of research in this field.
-
-### Types of Language Models
-**Types of Language Models: An Overview**
-
-Language models have revolutionized the field of natural language processing (NLP) by enabling machines to understand, generate, and interact with human language. With the rapid advancements in artificial intelligence (AI) and machine learning (ML), the development of language models has become a crucial area of research. In this chapter, we will delve into the various types of language models, exploring their characteristics, applications, and limitations.
-
-**1. Rule-Based Language Models**
-
-Rule-based language models, also known as symbolic models, rely on a set of predefined rules and grammatical structures to generate language. These models are based on the idea that language can be broken down into smaller components, such as words, phrases, and sentences, and that these components can be combined using specific rules to generate coherent language.
-
-Characteristics:
-
-* Rely on hand-coded rules and grammatical structures
-* Focus on syntax and semantics
-* Can be used for tasks such as language translation and text summarization
-
-Applications:
-
-* Language translation
-* Text summarization
-* Sentiment analysis
-
-Limitations:
-
-* Limited to the scope of the predefined rules
-* May not generalize well to new or unseen data
-* Can be time-consuming and labor-intensive to develop
-
-**2. Statistical Language Models**
-
-Statistical language models, also known as probabilistic models, use statistical techniques to analyze large datasets and generate language. These models are based on the idea that language can be modeled as a probability distribution over possible sentences or phrases.
-
-Characteristics:
-
-* Use statistical techniques to analyze large datasets
-* Focus on the probability of language patterns
-* Can be used for tasks such as language translation and text classification
-
-Applications:
-
-* Language translation
-* Text classification
-* Sentiment analysis
-
-Limitations:
-
-* Require large amounts of training data
-* Can be computationally expensive
-* May not generalize well to new or unseen data
-
-**3. Neural Language Models**
-
-Neural language models, also known as deep learning models, use artificial neural networks to analyze and generate language. These models are based on the idea that language can be modeled as a complex pattern recognition problem.
-
-Characteristics:
-
-* Use artificial neural networks to analyze and generate language
-* Focus on the patterns and structures of language
-* Can be used for tasks such as language translation and text generation
-
-Applications:
-
-* Language translation
-* Text generation
-* Sentiment analysis
-
-Limitations:
-
-* Require large amounts of training data
-* Can be computationally expensive
-* May not generalize well to new or unseen data
-
-**4. Hybrid Language Models**
-
-Hybrid language models combine the strengths of different types of language models to generate language. These models are based on the idea that language can be modeled as a combination of symbolic, statistical, and neural approaches.
-
-Characteristics:
-
-* Combine the strengths of different types of language models
-* Focus on the integration of different approaches
-* Can be used for tasks such as language translation and text summarization
-
-Applications:
-
-* Language translation
-* Text summarization
-* Sentiment analysis
-
-Limitations:
-
-* Require careful integration of different approaches
-* Can be computationally expensive
-* May not generalize well to new or unseen data
-
-**Conclusion**
-
-In conclusion, language models have come a long way in revolutionizing the field of NLP. From rule-based models to neural networks, each type of language model has its own strengths and limitations. Understanding the characteristics, applications, and limitations of different types of language models is crucial for developing effective NLP systems. As the field of NLP continues to evolve, it is essential to explore new approaches and integrate different types of language models to achieve better results.
-
-### Probability Theory
-**Chapter 1: Probability Theory: Introduction to Probability Theory and its Relevance to Language Models**
+## Chapter 1: Introduction to Natural Language Processing
+**Chapter 1: Introduction to Natural Language Processing: Overview of NLP, History, and Applications**
 
 **1.1 Introduction**
 
-Probability theory is a branch of mathematics that deals with the study of chance events and their likelihood of occurrence. It is a fundamental concept in many fields, including statistics, engineering, economics, and even language processing. In this chapter, we will introduce the basics of probability theory and explore its relevance to language models.
+Natural Language Processing (NLP) is a subfield of artificial intelligence (AI) that deals with the interaction between computers and humans in natural language. NLP is concerned with the development of algorithms and statistical models that enable computers to process, understand, and generate natural language data. In this chapter, we will provide an overview of NLP, its history, and its various applications.
 
-**1.2 What is Probability?**
+**1.2 What is Natural Language Processing?**
 
-Probability is a measure of the likelihood of an event occurring. It is a number between 0 and 1, where 0 represents an impossible event and 1 represents a certain event. The probability of an event is often denoted by the symbol P(A) and is calculated as the ratio of the number of favorable outcomes to the total number of possible outcomes.
+NLP is a multidisciplinary field that draws from linguistics, computer science, and cognitive psychology. It involves the development of algorithms and statistical models that enable computers to perform tasks such as:
 
-**1.3 Basic Concepts**
+* Tokenization: breaking down text into individual words or tokens
+* Part-of-speech tagging: identifying the grammatical category of each word (e.g., noun, verb, adjective)
+* Named entity recognition: identifying specific entities such as names, locations, and organizations
+* Sentiment analysis: determining the emotional tone or sentiment of text
+* Machine translation: translating text from one language to another
 
-There are several basic concepts in probability theory that are essential to understand:
+NLP has many applications in areas such as:
 
-* **Event**: A set of outcomes of an experiment.
-* **Sample Space**: The set of all possible outcomes of an experiment.
-* **Experiment**: An action or situation that produces a set of outcomes.
-* **Probability Measure**: A function that assigns a probability to each event.
+* Language translation: enabling computers to translate text from one language to another
+* Sentiment analysis: analyzing customer feedback and sentiment in social media
+* Chatbots: enabling computers to have conversations with humans
+* Text summarization: summarizing large documents and articles
 
-**1.4 Types of Events**
+**1.3 History of NLP**
 
-There are several types of events in probability theory:
+The history of NLP dates back to the 1950s when the first NLP program was developed. The field has undergone significant developments over the years, with major advancements in the 1980s and 1990s. The 2000s saw the rise of machine learning and deep learning techniques, which have revolutionized the field.
 
-* **Singleton**: An event that consists of a single outcome.
-* **Finite Union**: The union of a finite number of events.
-* **Countable Union**: The union of a countable number of events.
-* **Complement**: The set of all outcomes that are not in an event.
+Some notable milestones in the history of NLP include:
 
-**1.5 Probability Rules**
+* 1950s: The first NLP program was developed at the Massachusetts Institute of Technology (MIT)
+* 1960s: The development of the first natural language processing algorithms
+* 1980s: The introduction of machine learning techniques in NLP
+* 1990s: The development of statistical models for NLP
+* 2000s: The rise of machine learning and deep learning techniques in NLP
 
-There are several rules that govern the calculation of probabilities:
+**1.4 Applications of NLP**
 
-* **Addition Rule**: The probability of the union of two events is the sum of their individual probabilities.
-* **Multiplication Rule**: The probability of the intersection of two events is the product of their individual probabilities.
-* **Complement Rule**: The probability of the complement of an event is 1 minus the probability of the event.
+NLP has many applications across various industries, including:
 
-**1.6 Conditional Probability**
+* Customer service: chatbots and virtual assistants
+* Healthcare: medical record analysis and diagnosis
+* Marketing: sentiment analysis and customer feedback analysis
+* Education: language learning and assessment
+* Finance: text analysis and sentiment analysis
 
-Conditional probability is the probability of an event occurring given that another event has occurred. It is denoted by P(A|B) and is calculated as the ratio of the number of favorable outcomes to the total number of possible outcomes, given that event B has occurred.
+Some examples of NLP applications include:
 
-**1.7 Bayes' Theorem**
+* IBM Watson: a question-answering computer system that uses NLP to answer questions
+* Google Translate: a machine translation system that uses NLP to translate text
+* Siri and Alexa: virtual assistants that use NLP to understand voice commands
 
-Bayes' theorem is a fundamental result in probability theory that relates the conditional probability of an event given that another event has occurred to the prior probability of the event. It is often used in Bayesian inference and is a crucial concept in machine learning and natural language processing.
+**1.5 Conclusion**
 
-**1.8 Relevance to Language Models**
-
-Probability theory is essential in language models as it provides a mathematical framework for modeling the uncertainty of language. Language models are probabilistic models that assign a probability to each word or phrase given the context. This allows the model to make predictions about the next word or phrase in a sentence.
-
-**1.9 Applications in NLP**
-
-Probability theory has numerous applications in natural language processing (NLP), including:
-
-* **Language Modeling**: Probability theory is used to model the probability of a word or phrase given the context.
-* **Part-of-Speech Tagging**: Probability theory is used to assign a part-of-speech tag to a word based on its context.
-* **Named Entity Recognition**: Probability theory is used to identify named entities in text.
-* **Machine Translation**: Probability theory is used to model the probability of a translation given the source and target languages.
-
-**1.10 Conclusion**
-
-In this chapter, we have introduced the basics of probability theory and its relevance to language models. Probability theory provides a mathematical framework for modeling the uncertainty of language and is essential in many applications of NLP. In the next chapter, we will explore the application of probability theory to language models in more detail.
+In this chapter, we have provided an overview of NLP, its history, and its applications. NLP is a rapidly growing field that has many practical applications across various industries. As the field continues to evolve, we can expect to see even more innovative applications of NLP in the future.
 
 **References**
 
-* [1] Grimmett, G., & Stirzaker, D. (2001). Probability and Random Processes. Oxford University Press.
-* [2] Cover, T. M., & Thomas, J. A. (2006). Elements of Information Theory. John Wiley & Sons.
-* [3] Jurafsky, D., & Martin, J. H. (2000). Speech and Language Processing. Prentice Hall.
-
-### Statistical Modeling
-**Statistical Modeling: Introduction to Statistical Modeling and its Application to Language Models**
-
-**Introduction**
-
-Statistical modeling is a fundamental concept in data analysis and machine learning, enabling us to extract insights and make predictions from complex data sets. In the context of language models, statistical modeling plays a crucial role in understanding the underlying patterns and structures of language. This chapter provides an introduction to statistical modeling and its application to language models, exploring the theoretical foundations, key concepts, and practical applications of this powerful tool.
-
-**What is Statistical Modeling?**
-
-Statistical modeling is a mathematical framework for analyzing and interpreting data. It involves using statistical techniques to identify patterns, relationships, and trends in data, and to make predictions or inferences about future outcomes. Statistical modeling is based on the principles of probability theory and is used to quantify uncertainty and make predictions in the presence of uncertainty.
-
-**Key Concepts in Statistical Modeling**
-
-1. **Probability Theory**: Probability theory provides the mathematical foundation for statistical modeling. It deals with the study of chance events and the quantification of uncertainty.
-2. **Random Variables**: Random variables are variables whose values are uncertain and can take on different values with different probabilities.
-3. **Probability Distributions**: Probability distributions describe the probability of different outcomes of a random variable. Common probability distributions include the normal distribution, binomial distribution, and Poisson distribution.
-4. **Hypothesis Testing**: Hypothesis testing involves testing a hypothesis about a population parameter based on a sample of data.
-5. **Confidence Intervals**: Confidence intervals provide a range of values within which a population parameter is likely to lie.
-
-**Applications of Statistical Modeling to Language Models**
-
-1. **Language Modeling**: Statistical modeling is used to develop language models that can generate text, predict the next word in a sequence, and understand the meaning of text.
-2. **Part-of-Speech Tagging**: Statistical modeling is used to identify the part of speech (noun, verb, adjective, etc.) of each word in a sentence.
-3. **Named Entity Recognition**: Statistical modeling is used to identify and extract specific entities such as names, locations, and organizations from text.
-4. **Sentiment Analysis**: Statistical modeling is used to analyze the sentiment (positive, negative, or neutral) of text.
-5. **Machine Translation**: Statistical modeling is used to translate text from one language to another.
-
-**Types of Statistical Models**
-
-1. **Linear Regression**: Linear regression is used to model the relationship between a dependent variable and one or more independent variables.
-2. **Logistic Regression**: Logistic regression is used to model the probability of a binary outcome (0/1, yes/no, etc.) based on one or more independent variables.
-3. **Markov Chain**: Markov chains are used to model the probability of transitioning from one state to another.
-4. **Hidden Markov Model**: Hidden Markov models are used to model the probability of observing a sequence of symbols based on a hidden state.
-
-**Advantages and Challenges of Statistical Modeling in Language Models**
-
-Advantages:
-
-* Enables the development of accurate and robust language models
-* Allows for the analysis of complex patterns and relationships in language data
-* Enables the prediction of future outcomes and the identification of trends
-
-Challenges:
-
-* Requires a strong understanding of statistical theory and mathematical concepts
-* Can be computationally intensive and require large amounts of data
-* Can be sensitive to the quality and accuracy of the data used to train the model
-
-**Conclusion**
-
-Statistical modeling is a powerful tool for analyzing and understanding complex data sets, including language data. By applying statistical modeling techniques, researchers and developers can build more accurate and robust language models that can better understand and generate human language. This chapter has provided an introduction to statistical modeling and its application to language models, highlighting the key concepts, types of statistical models, and advantages and challenges of using statistical modeling in language models.
-
-### Introduction to Neural Networks
-**Chapter 1: Introduction to Neural Networks: Overview of Neural Networks and Their Application to Language Models**
-
-**1.1 Introduction**
-
-In recent years, neural networks have revolutionized the field of artificial intelligence, enabling machines to learn and improve their performance on complex tasks. At the heart of this revolution are neural networks, a type of machine learning model inspired by the structure and function of the human brain. In this chapter, we will delve into the world of neural networks, exploring their fundamental concepts, architectures, and applications, with a focus on their application to language models.
-
-**1.2 What are Neural Networks?**
-
-A neural network is a complex system composed of interconnected nodes or "neurons," which process and transmit information. Each neuron receives one or more inputs, performs a computation on those inputs, and then sends the output to other neurons. This process allows the network to learn and represent complex patterns in data.
-
-**1.3 History of Neural Networks**
-
-The concept of neural networks dates back to the 1940s, when Warren McCulloch and Walter Pitts proposed the first mathematical model of a neural network. However, it wasn't until the 1980s that neural networks began to gain popularity, thanks in part to the work of David Rumelhart, Geoffrey Hinton, and Ronald Williams, who developed the backpropagation algorithm, a key component of modern neural networks.
-
-**1.4 Types of Neural Networks**
-
-There are several types of neural networks, each designed to solve specific problems. Some common types include:
-
-1. **Feedforward Networks**: The most common type of neural network, where data flows only in one direction, from input nodes to output nodes, without any feedback loops.
-2. **Recurrent Neural Networks (RNNs)**: Designed to handle sequential data, RNNs allow information to flow in a loop, enabling the network to keep track of information over time.
-3. **Convolutional Neural Networks (CNNs)**: Used for image and signal processing, CNNs are optimized for processing data with grid-like topology, such as images.
-
-**1.5 Neural Network Architectures**
-
-Neural networks can be organized in various ways to solve specific problems. Some common architectures include:
-
-1. **Multilayer Perceptron (MLP)**: A feedforward network composed of multiple layers, each processing the output from the previous layer.
-2. **Autoencoder**: A neural network that learns to compress and reconstruct input data.
-3. **Generative Adversarial Networks (GANs)**: A type of neural network that generates new data samples by learning to distinguish between real and fake data.
-
-**1.6 Applications of Neural Networks**
-
-Neural networks have numerous applications across various fields, including:
-
-1. **Computer Vision**: Neural networks are used for image recognition, object detection, and image segmentation.
-2. **Natural Language Processing (NLP)**: Neural networks are used for language modeling, machine translation, and sentiment analysis.
-3. **Speech Recognition**: Neural networks are used for speech recognition, speech synthesis, and speech enhancement.
-
-**1.7 Language Models and Neural Networks**
-
-Language models are a type of neural network designed to process and generate human-like language. They are trained on large datasets of text and can be used for a variety of NLP tasks, such as:
-
-1. **Language Translation**: Neural networks can be used to translate text from one language to another.
-2. **Text Summarization**: Neural networks can be used to summarize long pieces of text into shorter summaries.
-3. **Chatbots**: Neural networks can be used to power conversational interfaces, such as chatbots and virtual assistants.
-
-**1.8 Conclusion**
-
-In this chapter, we have explored the basics of neural networks, including their history, types, architectures, and applications. We have also touched on the application of neural networks to language models, highlighting their potential to revolutionize the field of natural language processing. In the next chapter, we will delve deeper into the mathematics and implementation of neural networks, providing a comprehensive overview of the techniques and tools used to build and train these powerful models.
-
-### Recurrent Neural Networks (RNNs)
-**Recurrent Neural Networks (RNNs): Explanation of RNNs and their use in language models**
-
-Recurrent Neural Networks (RNNs) are a type of neural network architecture that is particularly well-suited for modeling sequential data, such as text, speech, or time series data. In this chapter, we will delve into the concept of RNNs, their components, and their applications in language models.
-
-**What are Recurrent Neural Networks (RNNs)?**
-
-Recurrent Neural Networks are a type of neural network that is designed to handle sequential data. Unlike traditional neural networks, which are designed to process fixed-size inputs, RNNs are designed to process input sequences of varying lengths. This is achieved through the use of recurrent connections, which allow the network to maintain a hidden state that is updated at each time step.
-
-**Components of RNNs**
-
-An RNN consists of the following components:
-
-1. **Input Gate**: The input gate is responsible for controlling the flow of information into the network. It takes the current input and the previous hidden state as input and produces a new hidden state.
-2. **Hidden State**: The hidden state is a vector that represents the internal state of the network. It is updated at each time step based on the input and the previous hidden state.
-3. **Output Gate**: The output gate is responsible for producing the output of the network. It takes the current hidden state and produces an output.
-4. **Cell State**: The cell state is a vector that represents the internal memory of the network. It is updated at each time step based on the input and the previous cell state.
-
-**How RNNs Work**
-
-RNNs work by iterating over the input sequence one time step at a time. At each time step, the input gate takes the current input and the previous hidden state as input and produces a new hidden state. The hidden state is then used to produce an output, which is the output of the network at that time step.
-
-**Types of RNNs**
-
-There are several types of RNNs, including:
-
-1. **Simple RNNs**: Simple RNNs are the most basic type of RNN. They use a single layer of neurons to process the input sequence.
-2. **Long Short-Term Memory (LSTM) Networks**: LSTMs are a type of RNN that is designed to handle the vanishing gradient problem. They use a memory cell to store information and a forget gate to decide what information to forget.
-3. **Gated Recurrent Units (GRUs)**: GRUs are a type of RNN that is similar to LSTMs but uses a simpler architecture.
-
-**Applications of RNNs in Language Models**
-
-RNNs have many applications in language models, including:
-
-1. **Language Modeling**: RNNs can be used to model the probability distribution of a sequence of words in a language.
-2. **Machine Translation**: RNNs can be used to translate text from one language to another.
-3. **Speech Recognition**: RNNs can be used to recognize spoken language and transcribe it into text.
-4. **Text Summarization**: RNNs can be used to summarize long pieces of text.
-
-**Challenges and Limitations of RNNs**
-
-Despite their many applications, RNNs have several challenges and limitations, including:
-
-1. **Vanishing Gradient Problem**: The vanishing gradient problem occurs when the gradients of the loss function become very small during backpropagation, making it difficult to train the network.
-2. **Exploding Gradient Problem**: The exploding gradient problem occurs when the gradients of the loss function become very large during backpropagation, making it difficult to train the network.
-3. **Overfitting**: RNNs can suffer from overfitting, especially when the input sequence is long.
-
-**Conclusion**
-
-In conclusion, RNNs are a powerful tool for modeling sequential data and have many applications in language models. While they have several challenges and limitations, they are a fundamental component of many natural language processing tasks.
-
-### Introduction to Transformers
-**Introduction to Transformers: Explanation of the Transformer Architecture and its Application to Large Language Models**
-
-The transformer architecture, introduced in 2017 by Vaswani et al. in the paper "Attention Is All You Need," revolutionized the field of natural language processing (NLP) by providing a new paradigm for sequence-to-sequence tasks. The transformer's ability to process long-range dependencies and capture complex contextual relationships has led to state-of-the-art results in a wide range of NLP tasks, including machine translation, text summarization, and language modeling. In this chapter, we will delve into the transformer architecture, its components, and its applications to large language models.
-
-**The Transformer Architecture**
-
-The transformer architecture is primarily designed for sequence-to-sequence tasks, such as machine translation and text summarization. It consists of an encoder and a decoder, both of which are composed of identical layers. Each layer consists of two sub-layers: a self-attention mechanism and a feed-forward neural network (FFNN).
-
-**Self-Attention Mechanism**
-
-The self-attention mechanism is the core component of the transformer architecture. It allows the model to attend to different parts of the input sequence simultaneously and weigh their importance. This is particularly useful for capturing long-range dependencies and complex contextual relationships.
-
-The self-attention mechanism is composed of three main components:
-
-1. **Query (Q)**: The query represents the input sequence, which is the input to the self-attention mechanism.
-2. **Key (K)**: The key represents the input sequence, which is used to compute the attention weights.
-3. **Value (V)**: The value represents the input sequence, which is used to compute the output of the self-attention mechanism.
-
-The self-attention mechanism computes the attention weights by taking the dot product of the query and key, and applying a softmax function to the result. The output of the self-attention mechanism is a weighted sum of the value, where the weights are the attention weights.
-
-**Feed-Forward Neural Network (FFNN)**
-
-The FFNN is a fully connected feed-forward neural network that is used to transform the output of the self-attention mechanism. It consists of two linear layers with a ReLU activation function in between.
-
-**Encoder**
-
-The encoder is responsible for processing the input sequence and generating a continuous representation of the input. It consists of multiple identical layers, each of which applies the self-attention mechanism and the FFNN.
-
-**Decoder**
-
-The decoder is responsible for generating the output sequence. It consists of multiple identical layers, each of which applies the self-attention mechanism and the FFNN. The decoder also uses the encoder output as input.
-
-**Applications to Large Language Models**
-
-The transformer architecture has been widely applied to large language models, including BERT, RoBERTa, and XLNet. These models have achieved state-of-the-art results in a wide range of NLP tasks, including sentiment analysis, question answering, and text classification.
-
-**BERT (Bidirectional Encoder Representations from Transformers)**
-
-BERT is a pre-trained language model that uses the transformer architecture to generate contextualized representations of words in a sentence. It has achieved state-of-the-art results in a wide range of NLP tasks, including sentiment analysis, question answering, and text classification.
-
-**RoBERTa (Robustly Optimized BERT Pretraining Approach)**
-
-RoBERTa is a pre-trained language model that uses the transformer architecture to generate contextualized representations of words in a sentence. It has achieved state-of-the-art results in a wide range of NLP tasks, including sentiment analysis, question answering, and text classification.
-
-**XLNet (Extreme Language Model)**
-
-XLNet is a pre-trained language model that uses the transformer architecture to generate contextualized representations of words in a sentence. It has achieved state-of-the-art results in a wide range of NLP tasks, including sentiment analysis, question answering, and text classification.
-
-**Conclusion**
-
-In this chapter, we have introduced the transformer architecture and its components, including the self-attention mechanism and the feed-forward neural network. We have also discussed the applications of the transformer architecture to large language models, including BERT, RoBERTa, and XLNet. These models have achieved state-of-the-art results in a wide range of NLP tasks, and have revolutionized the field of NLP.
-
-### Self-Attention Mechanism
-**Self-Attention Mechanism: In-depth Explanation**
-
-The self-attention mechanism is a crucial component of modern neural networks, particularly in the realm of natural language processing and deep learning. In this chapter, we will delve into the intricacies of the self-attention mechanism, exploring its concept, working, and applications.
-
-**What is Self-Attention?**
-
-Self-attention is a mechanism that allows a neural network to focus on specific parts of the input data while processing it. This is achieved by computing the relevance of each input element to every other element, and then using this relevance to weigh the importance of each element. This process enables the network to selectively attend to specific parts of the input, rather than treating all elements equally.
-
-**How Does Self-Attention Work?**
-
-The self-attention mechanism consists of three primary components: the Query (Q), the Key (K), and the Value (V). These components are computed from the input data and are used to compute the attention weights.
-
-1. **Query (Q)**: The query represents the input data that we want to attend to. It is typically computed using a neural network layer, such as a fully connected layer or a convolutional layer.
-2. **Key (K)**: The key represents the input data that we want to attend from. It is also computed using a neural network layer, similar to the query.
-3. **Value (V)**: The value represents the input data that we want to derive information from. It is typically computed using a neural network layer, similar to the query and key.
-
-The self-attention mechanism computes the attention weights by taking the dot product of the query and key, and then applying a softmax function to normalize the weights. The attention weights are then used to compute the output by taking the dot product of the attention weights and the value.
-
-**Mathematical Representation**
-
-The self-attention mechanism can be mathematically represented as follows:
-
-* Compute the query, key, and value matrices: Q = Q(X), K = K(X), V = V(X)
-* Compute the attention weights: Attention(Q, K) = softmax(Q * K^T / sqrt(d))
-* Compute the output: Output = Attention(Q, K) * V
-
-where X represents the input data, Q, K, and V are the query, key, and value matrices, respectively, and d is the dimensionality of the input data.
-
-**Applications of Self-Attention**
-
-Self-attention has numerous applications in various fields, including:
-
-1. **Natural Language Processing**: Self-attention is widely used in natural language processing tasks such as machine translation, text summarization, and question answering.
-2. **Computer Vision**: Self-attention is used in computer vision tasks such as image captioning, visual question answering, and image generation.
-3. **Speech Recognition**: Self-attention is used in speech recognition tasks such as speech-to-text and speaker recognition.
-4. **Time Series Analysis**: Self-attention is used in time series analysis tasks such as stock market prediction and weather forecasting.
-
-**Challenges and Limitations**
-
-While self-attention has revolutionized the field of deep learning, it is not without its challenges and limitations. Some of the challenges and limitations include:
-
-1. **Computational Complexity**: Self-attention can be computationally expensive, especially for large input sizes.
-2. **Overfitting**: Self-attention can lead to overfitting if not properly regularized.
-3. **Interpretability**: Self-attention can be difficult to interpret, making it challenging to understand the reasoning behind the model's predictions.
-
-**Conclusion**
-
-In conclusion, the self-attention mechanism is a powerful tool for processing sequential data, enabling neural networks to selectively focus on specific parts of the input data. While it has numerous applications in various fields, it is not without its challenges and limitations. By understanding the intricacies of self-attention, we can better harness its potential and unlock new possibilities in the realm of deep learning.
-
-### Introduction to BERT
-**Introduction to BERT: Overview of BERT and its significance in large language models**
-
-**1.1 Introduction**
-
-The advent of deep learning has revolutionized the field of natural language processing (NLP), enabling machines to comprehend and generate human-like language. Among the numerous breakthroughs in NLP, the development of BERT (Bidirectional Encoder Representations from Transformers) has had a profound impact on the field. In this chapter, we will delve into the world of BERT, exploring its significance in large language models and the impact it has had on the NLP community.
-
-**1.2 What is BERT?**
-
-BERT is a pre-trained language model developed by Google in 2018. It is a multi-layer bidirectional transformer encoder that uses a masked language modeling objective to predict the missing word in a sentence. The model is trained on a large corpus of text, such as the entire Wikipedia and BookCorpus, to learn the contextual relationships between words. This training process enables BERT to capture a wide range of linguistic phenomena, including syntax, semantics, and pragmatics.
-
-**1.3 Key Features of BERT**
-
-BERT's architecture is based on the transformer model, which is particularly well-suited for sequence-to-sequence tasks. The key features of BERT include:
-
-* **Bidirectional Encoding**: BERT uses a bidirectional encoder, which means that it processes the input sequence in both the forward and backward directions. This allows the model to capture the context of the input sequence more effectively.
-* **Multi-Layer Perceptrons (MLPs)**: BERT uses multiple layers of MLPs to process the input sequence. Each layer consists of a self-attention mechanism and a feed-forward neural network.
-* **Self-Attention Mechanism**: The self-attention mechanism allows the model to focus on specific parts of the input sequence when computing the output. This enables the model to capture long-range dependencies and contextual relationships between words.
-* **Pre-Training**: BERT is pre-trained on a large corpus of text, which allows it to learn the contextual relationships between words and capture a wide range of linguistic phenomena.
-
-**1.4 Significance of BERT in Large Language Models**
-
-BERT's significance in large language models lies in its ability to capture complex linguistic phenomena and its versatility in a wide range of NLP tasks. Some of the key benefits of BERT include:
-
-* **Improved Performance**: BERT has been shown to significantly improve the performance of various NLP tasks, including sentiment analysis, question answering, and text classification.
-* **Transfer Learning**: BERT's pre-training process allows it to learn a wide range of linguistic phenomena, which can be fine-tuned for specific tasks. This enables the model to adapt to new tasks and datasets with minimal additional training data.
-* **Interpretability**: BERT's architecture allows for interpretability, enabling researchers to understand the model's decision-making process and identify areas for improvement.
-* **Scalability**: BERT's architecture is scalable, allowing it to be applied to a wide range of NLP tasks and datasets.
-
-**1.5 Applications of BERT**
-
-BERT's significance extends beyond its use in large language models. Some of the key applications of BERT include:
-
-* **Question Answering**: BERT has been used to improve question answering systems, enabling machines to accurately identify the answers to complex questions.
-* **Sentiment Analysis**: BERT has been used to improve sentiment analysis systems, enabling machines to accurately identify the sentiment of text.
-* **Text Classification**: BERT has been used to improve text classification systems, enabling machines to accurately classify text into specific categories.
-* **Machine Translation**: BERT has been used to improve machine translation systems, enabling machines to accurately translate text from one language to another.
-
-**1.6 Conclusion**
-
-In conclusion, BERT is a groundbreaking language model that has revolutionized the field of NLP. Its ability to capture complex linguistic phenomena and its versatility in a wide range of NLP tasks make it a powerful tool for researchers and practitioners. As the field of NLP continues to evolve, it is likely that BERT will play an increasingly important role in the development of new language models and applications.
-
-### BERT Variants
-**BERT Variants: Explanation of BERT variants and their applications**
-
-**Introduction**
-
-BERT (Bidirectional Encoder Representations from Transformers) has revolutionized the field of Natural Language Processing (NLP) by achieving state-of-the-art results in a wide range of NLP tasks. Since its introduction in 2018, BERT has been extensively fine-tuned and modified to suit specific tasks and domains. This chapter will delve into the various BERT variants, their architectures, and applications.
-
-**1. BERT Variants**
-
-BERT has spawned a plethora of variants, each designed to address specific challenges and tasks. Some of the notable BERT variants include:
-
-* **DistilBERT**: A smaller and more efficient version of BERT, designed to be more computationally efficient and suitable for deployment on mobile devices.
-* **RoBERTa**: A variant that removes the next sentence prediction task and uses a different approach to learn contextualized representations.
-* **Longformer**: A variant designed for long-range dependencies, using a combination of local and global self-attention mechanisms.
-* **BigBird**: A variant designed for long-range dependencies, using a combination of local and global self-attention mechanisms.
-* **ALBERT**: A variant that uses a different approach to learn contextualized representations, using a multi-layer bidirectional encoder.
-* **XLNet**: A variant that uses a different approach to learn contextualized representations, using a permutation-based self-attention mechanism.
-
-**2. Applications of BERT Variants**
-
-BERT variants have been applied to a wide range of NLP tasks, including:
-
-* **Text Classification**: BERT variants have been used for text classification tasks such as sentiment analysis, spam detection, and topic modeling.
-* **Question Answering**: BERT variants have been used for question answering tasks, such as answering questions on Wikipedia articles.
-* **Named Entity Recognition**: BERT variants have been used for named entity recognition tasks, such as identifying named entities in text.
-* **Machine Translation**: BERT variants have been used for machine translation tasks, such as translating text from one language to another.
-* **Summarization**: BERT variants have been used for summarization tasks, such as summarizing long documents.
-
-**3. Advantages and Limitations of BERT Variants**
-
-Each BERT variant has its own advantages and limitations. Some of the key advantages and limitations include:
-
-* **Advantages**:
-	+ Improved performance on specific tasks
-	+ Ability to handle long-range dependencies
-	+ Ability to handle out-of-vocabulary words
-* **Limitations**:
-	+ Computational efficiency
-	+ Limited to specific tasks and domains
-	+ Requires large amounts of training data
-
-**Conclusion**
-
-BERT variants have revolutionized the field of NLP by providing a range of models that can be fine-tuned for specific tasks and domains. Each BERT variant has its own strengths and weaknesses, and understanding the advantages and limitations of each variant is crucial for selecting the most suitable model for a specific task. As the field of NLP continues to evolve, it is likely that new BERT variants will emerge, providing even more powerful tools for NLP tasks.
-
-### RoBERTa and DistilBERT
-**RoBERTa and DistilBERT: Explanation of RoBERTa and DistilBERT Architectures**
-
-In recent years, the field of Natural Language Processing (NLP) has witnessed a significant surge in the development of transformer-based architectures, particularly in the realm of language models. Two of the most prominent and influential models in this space are RoBERTa and DistilBERT. In this chapter, we will delve into the architectures of both models, exploring their design choices, strengths, and limitations.
-
-**RoBERTa: A Robustly Optimized BERT Pretraining Approach**
-
-RoBERTa (Robustly Optimized BERT Pretraining Approach) is a variant of the original BERT (Bidirectional Encoder Representations from Transformers) model, introduced in 2019 by the Google AI team. RoBERTa is designed to improve the performance of BERT on a wide range of NLP tasks, including sentiment analysis, question answering, and language translation. The key innovations in RoBERTa lie in its training procedure and the modifications made to the original BERT architecture.
-
-**Architecture Overview**
-
-RoBERTa's architecture is based on the original BERT model, which consists of a multi-layer bidirectional transformer encoder. The encoder is composed of a stack of identical layers, each consisting of two sub-layers: a self-attention mechanism and a feed-forward network (FFN). The self-attention mechanism allows the model to attend to different parts of the input sequence simultaneously, while the FFN is used to transform the output of the self-attention mechanism.
-
-**Training Procedure**
-
-RoBERTa's training procedure is where it differs significantly from the original BERT model. Instead of using a combination of masked language modeling and next sentence prediction tasks, RoBERTa uses only the masked language modeling task. This change is motivated by the observation that the next sentence prediction task is not as effective as the masked language modeling task in improving the model's performance.
-
-Another key innovation in RoBERTa is the use of a larger batch size and a longer sequence length. This allows the model to process longer input sequences and capture more contextual information.
-
-**Strengths and Limitations**
-
-RoBERTa's strengths lie in its ability to generalize well across a wide range of NLP tasks and its robustness to out-of-vocabulary words. However, it also has some limitations. RoBERTa is computationally expensive and requires a significant amount of computational resources to train. Additionally, its performance may degrade when dealing with very long input sequences or when the input sequence contains a large number of out-of-vocabulary words.
-
-**DistilBERT: A Distilled BERT Model**
-
-DistilBERT is a smaller and more efficient variant of the original BERT model, introduced in 2019 by the Hugging Face team. DistilBERT is designed to be a more practical and deployable version of BERT, suitable for real-world applications where computational resources are limited.
-
-**Architecture Overview**
-
-DistilBERT's architecture is based on the original BERT model, but with some key modifications. The model consists of a multi-layer bidirectional transformer encoder, similar to BERT. However, DistilBERT uses a smaller number of layers and a smaller embedding size compared to BERT.
-
-**Training Procedure**
-
-DistilBERT is trained using a combination of masked language modeling and next sentence prediction tasks, similar to the original BERT model. However, DistilBERT uses a different training procedure, known as knowledge distillation, to learn from the original BERT model. In knowledge distillation, the student model (DistilBERT) is trained to mimic the output of the teacher model (BERT), rather than optimizing a specific objective function.
-
-**Strengths and Limitations**
-
-DistilBERT's strengths lie in its ability to achieve similar performance to BERT while being significantly smaller and more efficient. This makes it a more practical choice for real-world applications where computational resources are limited. However, DistilBERT's performance may degrade when dealing with very long input sequences or when the input sequence contains a large number of out-of-vocabulary words.
-
-**Comparison of RoBERTa and DistilBERT**
-
-Both RoBERTa and DistilBERT are powerful language models that have achieved state-of-the-art results in a wide range of NLP tasks. However, they differ in their design choices and strengths. RoBERTa is a more robust and generalizable model, but it is computationally expensive and requires a significant amount of computational resources to train. DistilBERT, on the other hand, is a more efficient and practical model, but its performance may degrade in certain scenarios.
-
-In conclusion, RoBERTa and DistilBERT are two influential models in the field of NLP, each with its own strengths and limitations. Understanding the architectures and training procedures of these models is essential for building and deploying effective NLP systems.
-
-### Other Large Language Models
-**Other Large Language Models: Overview of other large language models and their architectures**
-
-In the previous chapter, we delved into the architecture and capabilities of BERT, a groundbreaking language model that has revolutionized the field of natural language processing. However, BERT is not the only large language model that has gained significant attention in recent years. In this chapter, we will explore other notable large language models, their architectures, and their applications.
-
-**1. RoBERTa: A Robustly Optimized BERT Pretraining Approach**
-
-RoBERTa (Robustly Optimized BERT Pretraining Approach) is another popular language model developed by the Google AI team. RoBERTa is an extension of BERT, with several key improvements that enhance its performance on various NLP tasks. The main differences between RoBERTa and BERT are:
-
-* **Different optimization techniques**: RoBERTa uses a different optimization algorithm, AdamW, which is more robust to noisy gradients.
-* **Increased model size**: RoBERTa has a larger model size, with 355M parameters, compared to BERT's 110M parameters.
-* **More data**: RoBERTa is trained on a larger dataset, including the entire Wikipedia and BookCorpus datasets.
-
-RoBERTa has achieved state-of-the-art results on several NLP tasks, including sentiment analysis, question answering, and named entity recognition.
-
-**2. XLNet: A Generalized Permutation-Based Encoder for Efficient Language Modeling**
-
-XLNet is a novel language model developed by the Carnegie Mellon University team. XLNet is designed to address the limitations of traditional language models, such as:
-
-* **Overfitting**: XLNet uses a permutation-based encoder that randomly permutes the input sequence, which helps to reduce overfitting.
-* **Scalability**: XLNet is designed to be more scalable, with a smaller model size and faster training times.
-
-XLNet has achieved state-of-the-art results on several NLP tasks, including language modeling, sentiment analysis, and question answering.
-
-**3. ELECTRA: Efficiently Learning an Encoder that Classifies Token Replacements Accurately**
-
-ELECTRA (Efficiently Learning an Encoder that Classifies Token Replacements Accurately) is a language model developed by the Google AI team. ELECTRA is designed to be more efficient and scalable than traditional language models. The main innovations of ELECTRA are:
-
-* **Token replacement**: ELECTRA replaces tokens in the input sequence with a random token, which helps to reduce overfitting.
-* **Efficient training**: ELECTRA uses a novel training strategy that reduces the computational cost of training.
-
-ELECTRA has achieved state-of-the-art results on several NLP tasks, including language modeling, sentiment analysis, and question answering.
-
-**4. Longformer: The Longformer: The Longformer: The Longformer: The Longformer**
-
-Longformer is a novel language model developed by the University of California, Berkeley team. Longformer is designed to handle long-range dependencies in language, which is particularly challenging for traditional language models. The main innovations of Longformer are:
-
-* **Global attention**: Longformer uses a global attention mechanism that allows it to attend to all tokens in the input sequence, rather than just the tokens in the current window.
-* **Efficient training**: Longformer uses a novel training strategy that reduces the computational cost of training.
-
-Longformer has achieved state-of-the-art results on several NLP tasks, including language modeling, sentiment analysis, and question answering.
-
-**Conclusion**
-
-In this chapter, we have explored several notable large language models, including RoBERTa, XLNet, ELECTRA, and Longformer. Each of these models has its unique architecture and innovations that address specific challenges in natural language processing. These models have achieved state-of-the-art results on various NLP tasks and have the potential to revolutionize the field of NLP.
-
-### Training Objectives
-**Training Objectives: Explanation of Training Objectives for Large Language Models**
-
-In this chapter, we will delve into the importance of training objectives in the development of large language models. We will explore the various types of training objectives, their significance, and how they impact the performance of these models.
-
-**Introduction**
-
-Large language models have revolutionized the field of natural language processing (NLP) in recent years. These models have achieved state-of-the-art results in various NLP tasks, such as language translation, text classification, and question answering. However, the development of these models relies heavily on the choice of training objectives. In this chapter, we will discuss the importance of training objectives and explore the different types of objectives used in large language model training.
-
-**What are Training Objectives?**
-
-Training objectives are the goals that a model strives to achieve during the training process. In the context of large language models, training objectives are the criteria used to evaluate the model's performance and guide its learning process. The choice of training objective is crucial, as it determines the model's ability to learn and generalize to new, unseen data.
-
-**Types of Training Objectives**
-
-There are several types of training objectives used in large language model training. Some of the most common objectives include:
-
-1. **Maximum Likelihood Estimation (MLE)**: MLE is a widely used training objective in NLP. The goal of MLE is to maximize the likelihood of the model's predictions given the input data. In other words, the model aims to predict the most likely output given the input.
-2. **Perplexity**: Perplexity is a measure of how well a model predicts a test set. The goal of perplexity is to minimize the perplexity score, which is calculated by taking the negative log-likelihood of the model's predictions.
-3. **Reinforcement Learning (RL)**: RL is a type of training objective that involves training a model to take actions in an environment. The goal of RL is to maximize the cumulative reward received from the environment.
-4. **Adversarial Training**: Adversarial training involves training a model to be robust to adversarial attacks. The goal of adversarial training is to minimize the model's loss on adversarial examples.
-
-**Significance of Training Objectives**
-
-The choice of training objective is crucial in large language model training. The objective determines the model's ability to learn and generalize to new data. For example, MLE is effective for tasks that require predicting the next word in a sequence, while perplexity is more suitable for tasks that require predicting the entire sequence.
-
-**Impact of Training Objectives on Model Performance**
-
-The choice of training objective has a significant impact on the performance of large language models. For example, MLE has been shown to be effective for tasks such as language translation and text classification, while perplexity has been shown to be effective for tasks such as language modeling and text summarization.
-
-**Conclusion**
-
-In conclusion, training objectives play a critical role in the development of large language models. The choice of training objective determines the model's ability to learn and generalize to new data. By understanding the different types of training objectives and their significance, researchers and practitioners can develop more effective large language models that achieve state-of-the-art results in various NLP tasks.
-
-**References**
-
-* [1] Brown, T. B., et al. (2020). Language models are few-shot learners. arXiv preprint arXiv:2005.14165.
-* [2] Radford, A., et al. (2019). Language models are unsupervised multitask learners. arXiv preprint arXiv:1906.08237.
-* [3] Devlin, J., et al. (2019). BERT: Pre-training of deep bidirectional transformers for language understanding. arXiv preprint arXiv:1810.04805.
+* [1] Jurafsky, D., & Martin, J. H. (2000). Speech and Language Processing. Prentice Hall.
+* [2] Manning, C. D., & Schütze, H. (1999). Foundations of Statistical Natural Language Processing. MIT Press.
+* [3] Russell, S. J., & Norvig, P. (2003). Artificial Intelligence: A Modern Approach. Prentice Hall.
 
 **Glossary**
 
-* **Maximum Likelihood Estimation (MLE)**: A training objective that aims to maximize the likelihood of the model's predictions given the input data.
-* **Perplexity**: A measure of how well a model predicts a test set.
-* **Reinforcement Learning (RL)**: A type of training objective that involves training a model to take actions in an environment.
-* **Adversarial Training**: A type of training objective that involves training a model to be robust to adversarial attacks.
+* NLP: Natural Language Processing
+* AI: Artificial Intelligence
+* ML: Machine Learning
+* DL: Deep Learning
+* NLU: Natural Language Understanding
+* NLG: Natural Language Generation
 
-### Optimization Techniques
-**Optimization Techniques: Overview of Optimization Techniques for Training Large Language Models**
+## Chapter 2: Language Models: Definition and Importance
+**Chapter 2: Language Models: Definition and Importance**
 
-Training large language models requires efficient optimization techniques to minimize the loss function and improve the model's performance. In this chapter, we will delve into the world of optimization techniques, exploring the most popular and effective methods used in training large language models.
+**Introduction**
 
-**1. Introduction to Optimization Techniques**
+Language models are a fundamental component of natural language processing (NLP) and have become increasingly important in recent years. In this chapter, we will delve into the definition, types, and significance of language models, providing a comprehensive overview of this crucial aspect of NLP.
 
-Optimization techniques are a crucial component of machine learning, as they enable models to learn from data and improve their performance over time. In the context of large language models, optimization techniques are used to minimize the loss function, which represents the difference between the model's predictions and the actual outputs. The goal of optimization is to find the optimal parameters that minimize the loss function, allowing the model to make accurate predictions.
+**Definition of Language Models**
 
-**2. Gradient Descent**
+A language model is a statistical model that predicts the likelihood of a sequence of words or characters in a natural language. It is a type of probabilistic model that assigns a probability distribution to a sequence of words or characters, allowing it to generate text that is coherent and grammatically correct. Language models are trained on large datasets of text and are used to predict the next word or character in a sequence, given the context of the previous words or characters.
 
-Gradient Descent (GD) is one of the most widely used optimization techniques in machine learning. GD is an iterative algorithm that updates the model's parameters based on the gradient of the loss function. The gradient represents the direction of steepest descent, guiding the model towards the optimal parameters.
+**Types of Language Models**
 
-**2.1. Batch Gradient Descent**
+There are several types of language models, each with its own strengths and weaknesses. Some of the most common types of language models include:
 
-Batch Gradient Descent (BGD) is a variant of GD that updates the model's parameters using the entire training dataset at once. BGD is computationally efficient but can be slow for large datasets.
+1. **N-gram Models**: N-gram models are based on the frequency of word sequences in a corpus of text. They are simple and effective, but can be limited by the size of the training dataset.
+2. **Markov Chain Models**: Markov chain models are based on the probability of transitioning from one state to another. They are more complex than N-gram models and can capture longer-range dependencies in language.
+3. **Recurrent Neural Network (RNN) Models**: RNN models are a type of deep learning model that uses recurrent neural networks to model the probability of a sequence of words or characters. They are more powerful than N-gram and Markov chain models, but can be computationally expensive.
+4. **Transformers**: Transformer models are a type of deep learning model that uses self-attention mechanisms to model the probability of a sequence of words or characters. They are highly effective and have become the state-of-the-art in many NLP tasks.
 
-**2.2. Stochastic Gradient Descent**
+**Significance of Language Models**
 
-Stochastic Gradient Descent (SGD) is another variant of GD that updates the model's parameters using a single training example at a time. SGD is computationally efficient and can handle large datasets but may converge slowly.
+Language models have several significant applications in NLP and beyond. Some of the most important applications include:
 
-**3. Momentum**
+1. **Text Generation**: Language models can be used to generate text that is coherent and grammatically correct. This can be used in applications such as chatbots, email generation, and content creation.
+2. **Language Translation**: Language models can be used to translate text from one language to another. This can be used in applications such as machine translation, subtitling, and dubbing.
+3. **Sentiment Analysis**: Language models can be used to analyze the sentiment of text, allowing for the detection of positive, negative, and neutral sentiment.
+4. **Question Answering**: Language models can be used to answer questions, allowing for the extraction of relevant information from large datasets.
 
-Momentum is a technique that accelerates the convergence of GD by incorporating a momentum term into the update rule. This helps the model to escape local minima and converge faster.
+**Conclusion**
 
-**4. Nesterov Accelerated Gradient**
-
-Nesterov Accelerated Gradient (NAG) is an optimization technique that combines the benefits of GD and momentum. NAG uses a momentum term to accelerate the convergence and a correction term to improve the model's stability.
-
-**5. Adam**
-
-Adam is a popular optimization technique that adapts the learning rate for each parameter individually. Adam uses a first-order optimization algorithm and is known for its robustness and stability.
-
-**6. RMSProp**
-
-RMSProp is another popular optimization technique that adapts the learning rate for each parameter individually. RMSProp is known for its ability to handle non-stationary data and is often used in deep learning applications.
-
-**7. Adagrad**
-
-Adagrad is an optimization technique that adapts the learning rate for each parameter individually. Adagrad is known for its ability to handle sparse data and is often used in natural language processing applications.
-
-**8. Adadelta**
-
-Adadelta is an optimization technique that adapts the learning rate for each parameter individually. Adadelta is known for its ability to handle non-stationary data and is often used in deep learning applications.
-
-**9. Conjugate Gradient**
-
-Conjugate Gradient (CG) is an optimization technique that uses a conjugate gradient method to minimize the loss function. CG is known for its ability to handle large datasets and is often used in linear algebra applications.
-
-**10. Quasi-Newton Methods**
-
-Quasi-Newton methods are optimization techniques that use an approximation of the Hessian matrix to minimize the loss function. Quasi-Newton methods are known for their ability to handle non-convex optimization problems and are often used in deep learning applications.
-
-**11. Conclusion**
-
-In this chapter, we have explored the most popular optimization techniques used in training large language models. From Gradient Descent to Quasi-Newton methods, each technique has its strengths and weaknesses, and choosing the right optimization technique is crucial for achieving optimal performance. By understanding the different optimization techniques, researchers and practitioners can develop more effective and efficient methods for training large language models.
+In this chapter, we have explored the definition, types, and significance of language models. Language models are a fundamental component of NLP and have many important applications in fields such as text generation, language translation, sentiment analysis, and question answering. As the field of NLP continues to evolve, language models will play an increasingly important role in shaping the future of human-computer interaction.
 
 **References**
 
-* [1] Kingma, D. P., & Ba, J. (2015). Adam: A Method for Stochastic Optimization. In Proceedings of the 30th International Conference on Machine Learning (pp. 1312-1320).
-* [2] Hinton, G. E., Osindero, D., & Teh, Y. W. (2006). A Fast Learning Algorithm for Deep Belief Nets. In Proceedings of the 13th International Conference on Artificial Intelligence and Statistics (pp. 350-357).
-* [3] Nesterov, Y. E. (1983). A method for finding a minimum of a function. Soviet Mathematics Doklady, 27(3), 372-376.
-* [4] Duchi, J. C., Hazan, E., & Singer, Y. (2011). Adaptive Subgradient Methods for Online Learning and Stochastic Optimization. Journal of Machine Learning Research, 12(1), 2121-2159.
+* [1] J. S. Brown, "The Mathematics of Language Models," Journal of Language and Linguistics, vol. 1, no. 1, pp. 1-15, 2018.
+* [2] Y. Kim, "Language Models for Natural Language Processing," Journal of Natural Language Processing, vol. 1, no. 1, pp. 1-15, 2019.
+* [3] A. Vaswani, "Attention Is All You Need," Advances in Neural Information Processing Systems, vol. 30, pp. 5998-6008, 2017.
 
-### Fine-Tuning Techniques
-**Fine-Tuning Techniques: Explanation of Fine-Tuning Techniques for Large Language Models**
+**Glossary**
 
-Fine-tuning is a crucial step in the process of adapting large language models to specific tasks and domains. In this chapter, we will delve into the world of fine-tuning techniques, exploring the various methods and strategies that can be employed to fine-tune large language models for optimal performance.
+* **N-gram**: A sequence of n items (such as words or characters) that appear together in a corpus of text.
+* **Markov Chain**: A mathematical system that undergoes transitions from one state to another, where the probability of transitioning from one state to another is based on the current state.
+* **Recurrent Neural Network (RNN)**: A type of neural network that uses recurrent connections to model the probability of a sequence of words or characters.
+* **Transformer**: A type of neural network that uses self-attention mechanisms to model the probability of a sequence of words or characters.
 
-**What is Fine-Tuning?**
+## Chapter 3: Mathematical Preliminaries
+**Chapter 3: Mathematical Preliminaries: Linear Algebra, Calculus, and Probability Theory for Language Models**
 
-Before diving into the world of fine-tuning techniques, it is essential to understand what fine-tuning is and why it is necessary. Fine-tuning is the process of adapting a pre-trained language model to a specific task or domain. This involves adjusting the model's parameters to better suit the requirements of the task at hand. Fine-tuning is necessary because pre-trained language models are typically trained on large datasets and are not specifically designed for a particular task. By fine-tuning the model, we can adapt it to the specific requirements of the task, resulting in improved performance and accuracy.
+This chapter provides a comprehensive overview of the mathematical concepts and techniques that are essential for understanding the underlying principles of language models. We will cover the fundamental concepts of linear algebra, calculus, and probability theory, which form the foundation of many machine learning and natural language processing techniques.
 
-**Types of Fine-Tuning Techniques**
+**3.1 Linear Algebra**
 
-There are several fine-tuning techniques that can be employed to adapt large language models to specific tasks and domains. Some of the most common techniques include:
+Linear algebra is a fundamental area of mathematics that deals with the study of linear equations, vector spaces, and linear transformations. In the context of language models, linear algebra is used to represent and manipulate high-dimensional data, such as word embeddings and sentence embeddings.
 
-### 1. **Supervised Fine-Tuning**
+**3.1.1 Vector Spaces**
 
-Supervised fine-tuning involves training the model on a labeled dataset, where the target output is provided for each input. This technique is particularly useful when the task at hand requires predicting a specific output, such as sentiment analysis or text classification.
+A vector space is a set of vectors that can be added together and scaled by numbers. In the context of language models, vectors are used to represent words, sentences, and documents. The vector space is a mathematical structure that enables the manipulation of these vectors.
 
-### 2. **Unsupervised Fine-Tuning**
+**Definition 3.1**: A vector space is a set V together with two operations:
 
-Unsupervised fine-tuning involves training the model on an unlabeled dataset, where the target output is not provided. This technique is particularly useful when the task at hand requires clustering or dimensionality reduction, such as topic modeling or document clustering.
+1. Vector addition: V × V → V, denoted by +, which satisfies the following properties:
+	* Commutativity: a + b = b + a
+	* Associativity: (a + c) + d = a + (c + d)
+	* Existence of additive identity: There exists an element 0 such that a + 0 = a
+	* Existence of additive inverse: For each element a, there exists an element -a such that a + (-a) = 0
+2. Scalar multiplication: V × F → V, denoted by ⋅, where F is a field (e.g., the real numbers) and satisfies the following properties:
+	* Distributivity: a ⋅ (b + c) = a ⋅ b + a ⋅ c
+	* Existence of multiplicative identity: There exists an element 1 such that a ⋅ 1 = a
+	* Existence of multiplicative inverse: For each non-zero element a, there exists an element a^(-1) such that a ⋅ a^(-1) = 1
 
-### 3. **Self-Supervised Fine-Tuning**
+**3.1.2 Linear Transformations**
 
-Self-supervised fine-tuning involves training the model on a dataset where the target output is not provided, but the model is still able to learn from the input data. This technique is particularly useful when the task at hand requires learning from unlabelled data, such as masked language modeling or next sentence prediction.
+A linear transformation is a function between vector spaces that preserves the operations of vector addition and scalar multiplication. In the context of language models, linear transformations are used to represent word embeddings and sentence embeddings.
 
-### 4. **Transfer Learning**
+**Definition 3.2**: A linear transformation is a function T: V → W between two vector spaces V and W that satisfies the following properties:
 
-Transfer learning involves pre-training the model on a large dataset and then fine-tuning it on a smaller dataset specific to the task at hand. This technique is particularly useful when the task at hand is similar to the pre-training task, such as fine-tuning a pre-trained language model on a specific domain or task.
+1. Linearity: T(a + b) = T(a) + T(b)
+2. Homogeneity: T(a ⋅ b) = a ⋅ T(b)
 
-### 5. **Multi-Task Learning**
+**3.1.3 Matrix Operations**
 
-Multi-task learning involves training the model on multiple tasks simultaneously, where the tasks are related to each other. This technique is particularly useful when the tasks at hand are related, such as sentiment analysis and topic modeling.
+Matrices are used to represent linear transformations between vector spaces. Matrix operations such as matrix multiplication and matrix inversion are essential for many machine learning and natural language processing techniques.
 
-**Fine-Tuning Strategies**
+**Definition 3.3**: A matrix is a rectangular array of numbers, symbols, or expressions, arranged in rows and columns.
 
-In addition to the various fine-tuning techniques, there are several strategies that can be employed to fine-tune large language models. Some of the most common strategies include:
+**3.2 Calculus**
 
-### 1. **Gradient Descent**
+Calculus is a branch of mathematics that deals with the study of rates of change and accumulation. In the context of language models, calculus is used to optimize the parameters of the model and to compute the gradient of the loss function.
 
-Gradient descent is a popular optimization algorithm used to fine-tune the model's parameters. This algorithm involves adjusting the model's parameters in the direction of the negative gradient of the loss function.
+**3.2.1 Limits**
 
-### 2. **Adam Optimization**
+The concept of limits is central to calculus. It is used to define the derivative and the integral.
 
-Adam optimization is a popular optimization algorithm used to fine-tune the model's parameters. This algorithm involves adjusting the model's parameters using a combination of gradient descent and momentum.
+**Definition 3.4**: The limit of a function f(x) as x approaches a is denoted by lim x→a f(x) and is defined as:
 
-### 3. **Learning Rate Scheduling**
+lim x→a f(x) = L if for every ε > 0, there exists a δ > 0 such that |f(x) - L| < ε for all x such that |x - a| < δ
 
-Learning rate scheduling involves adjusting the learning rate during the fine-tuning process. This technique is particularly useful when the model is not converging or when the loss function is not decreasing.
+**3.2.2 Derivatives**
 
-### 4. **Early Stopping**
+The derivative of a function is used to measure the rate of change of the function with respect to one of its variables.
 
-Early stopping involves stopping the fine-tuning process when the model's performance on the validation set starts to degrade. This technique is particularly useful when the model is overfitting to the training data.
+**Definition 3.5**: The derivative of a function f(x) at a point x=a is denoted by f'(a) and is defined as:
 
-**Conclusion**
+f'(a) = lim h→0 [f(a + h) - f(a)]/h
 
-Fine-tuning is a crucial step in the process of adapting large language models to specific tasks and domains. By employing various fine-tuning techniques and strategies, we can adapt the model to the specific requirements of the task at hand, resulting in improved performance and accuracy. In this chapter, we have explored the various fine-tuning techniques and strategies that can be employed to fine-tune large language models. By understanding these techniques and strategies, we can better adapt our models to the specific requirements of the task at hand, resulting in improved performance and accuracy.
+**3.2.3 Integrals**
 
-### Task-Specific Fine-Tuning
-**Task-Specific Fine-Tuning: Overview of Task-Specific Fine-Tuning for Large Language Models**
+The integral of a function is used to compute the accumulation of the function over a given interval.
 
-Task-specific fine-tuning is a crucial step in the process of adapting large language models to specific tasks or domains. In this chapter, we will delve into the world of task-specific fine-tuning, exploring the concept, benefits, and best practices for fine-tuning large language models for various tasks.
+**Definition 3.6**: The definite integral of a function f(x) from a to b is denoted by ∫[a,b] f(x) dx and is defined as:
 
-**What is Task-Specific Fine-Tuning?**
+∫[a,b] f(x) dx = F(b) - F(a)
 
-Task-specific fine-tuning is the process of adapting a pre-trained large language model to a specific task or domain. This involves updating the model's weights to optimize its performance on a particular task, such as sentiment analysis, question answering, or text classification. The goal of fine-tuning is to leverage the model's general knowledge and adapt it to the specific requirements of the target task.
+where F(x) is the antiderivative of f(x).
 
-**Benefits of Task-Specific Fine-Tuning**
+**3.3 Probability Theory**
 
-Fine-tuning large language models offers several benefits, including:
+Probability theory is a branch of mathematics that deals with the study of chance events and their probabilities. In the context of language models, probability theory is used to model the uncertainty of the language and to compute the likelihood of a sentence or a document.
 
-1. **Improved Performance**: Fine-tuning allows the model to learn task-specific patterns and relationships, leading to improved performance on the target task.
-2. **Reduced Overfitting**: By fine-tuning the model, you can reduce the risk of overfitting, which occurs when the model becomes too specialized to the training data and fails to generalize to new, unseen data.
-3. **Increased Flexibility**: Fine-tuning enables the model to adapt to different tasks and domains, making it a versatile tool for a wide range of applications.
-4. **Efficient Training**: Fine-tuning typically requires less training data and computational resources compared to training a model from scratch.
+**3.3.1 Basic Concepts**
 
-**Best Practices for Task-Specific Fine-Tuning**
+Probability theory is based on the following basic concepts:
 
-To ensure successful fine-tuning, follow these best practices:
+1. **Event**: A set of outcomes of an experiment.
+2. **Probability**: A measure of the likelihood of an event occurring.
+3. **Probability space**: A set of outcomes, a set of events, and a measure of probability.
 
-1. **Choose the Right Model**: Select a pre-trained model that is suitable for your task, considering factors such as the model's architecture, size, and training data.
-2. **Prepare High-Quality Training Data**: Ensure that your training data is high-quality, diverse, and representative of the target task.
-3. **Select the Right Hyperparameters**: Experiment with different hyperparameters, such as learning rate, batch size, and number of epochs, to find the optimal combination for your task.
-4. **Monitor Performance**: Regularly monitor the model's performance on a validation set to prevent overfitting and adjust hyperparameters as needed.
-5. **Use Transfer Learning**: Leverage the model's pre-trained knowledge by using transfer learning, which involves fine-tuning the model on a small amount of target task data.
-6. **Regularize the Model**: Regularize the model to prevent overfitting by adding regularization techniques, such as dropout or L1/L2 regularization.
-7. **Experiment and Iterate**: Be prepared to experiment and iterate on your fine-tuning process, as the optimal approach may vary depending on the task and dataset.
+**3.3.2 Probability Measures**
 
-**Common Challenges and Solutions**
+A probability measure is a function that assigns a probability to each event in the probability space.
 
-When fine-tuning large language models, you may encounter common challenges such as:
+**Definition 3.7**: A probability measure P is a function that assigns a probability to each event A in the probability space Ω, such that:
 
-1. **Overfitting**: Regularize the model, reduce the number of epochs, or increase the batch size to prevent overfitting.
-2. **Underfitting**: Increase the number of epochs, reduce the learning rate, or add more training data to improve the model's performance.
-3. **Computational Resources**: Use cloud-based services or distributed computing to reduce the computational burden and speed up the fine-tuning process.
+1. P(Ω) = 1
+2. P(∅) = 0
+3. For any countable collection {A_i} of disjoint events, P(∪A_i) = ∑ P(A_i)
 
-**Real-World Applications of Task-Specific Fine-Tuning**
+**3.3.3 Bayes' Theorem**
 
-Task-specific fine-tuning has numerous real-world applications, including:
+Bayes' theorem is a fundamental result in probability theory that relates the conditional probability of an event to the unconditional probability of the event and the conditional probability of the event given another event.
 
-1. **Sentiment Analysis**: Fine-tune a model to analyze customer reviews, social media posts, or online feedback.
-2. **Question Answering**: Fine-tune a model to answer questions on a specific topic or domain.
-3. **Text Classification**: Fine-tune a model to classify text into categories, such as spam vs. non-spam emails.
-4. **Machine Translation**: Fine-tune a model to translate text from one language to another.
+**Theorem 3.1**: Bayes' theorem states that for any events A and B, the conditional probability of A given B is:
 
-In conclusion, task-specific fine-tuning is a powerful technique for adapting large language models to specific tasks or domains. By understanding the benefits, best practices, and common challenges, you can effectively fine-tune your model to achieve state-of-the-art performance on your target task.
-
-### Text Classification
-**Text Classification: Explanation of Text Classification using Large Language Models**
-
-Text classification is a fundamental task in natural language processing (NLP) that involves assigning predefined categories or labels to unstructured text data. In this chapter, we will delve into the concept of text classification, its importance, and the role of large language models in this process.
-
-**What is Text Classification?**
-
-Text classification is a supervised learning problem where a model is trained to classify text into predefined categories or classes. The goal is to assign a relevant label or category to a piece of text based on its content, tone, and style. This task is crucial in various applications, such as:
-
-1. Sentiment Analysis: Classifying text as positive, negative, or neutral to analyze customer feedback or opinions.
-2. Spam Detection: Identifying spam emails or messages to filter out unwanted content.
-3. Topic Modeling: Categorizing text into topics or themes to analyze and summarize large documents.
-
-**How Text Classification Works**
-
-The text classification process involves the following steps:
-
-1. **Data Collection**: Gathering a large dataset of labeled text samples, where each sample is associated with a specific category or label.
-2. **Preprocessing**: Cleaning and normalizing the text data by removing stop words, punctuation, and converting all text to lowercase.
-3. **Feature Extraction**: Extracting relevant features from the text data, such as n-grams, word frequencies, or sentiment scores.
-4. **Model Training**: Training a machine learning model on the preprocessed data to learn the patterns and relationships between the text features and labels.
-5. **Model Evaluation**: Evaluating the performance of the trained model using metrics such as accuracy, precision, recall, and F1-score.
-
-**Large Language Models in Text Classification**
-
-Large language models have revolutionized the field of text classification by providing powerful tools for feature extraction and model training. These models are trained on massive datasets and can learn complex patterns and relationships in text data. Some popular large language models used in text classification include:
-
-1. **BERT (Bidirectional Encoder Representations from Transformers)**: A pre-trained language model that can be fine-tuned for specific NLP tasks, including text classification.
-2. **RoBERTa (Robustly Optimized BERT Pretraining Approach)**: A variant of BERT that uses a different approach to pre-training and has achieved state-of-the-art results in many NLP tasks.
-3. **DistilBERT**: A smaller and more efficient version of BERT that is designed for deployment on resource-constrained devices.
-
-**Advantages of Using Large Language Models**
-
-1. **Improved Performance**: Large language models can learn complex patterns and relationships in text data, leading to improved performance in text classification tasks.
-2. **Reduced Training Time**: Pre-trained language models can be fine-tuned for specific tasks, reducing the time and computational resources required for training.
-3. **Scalability**: Large language models can be easily scaled to handle large datasets and complex tasks.
-
-**Challenges and Limitations**
-
-1. **Data Quality**: The quality and diversity of the training data can significantly impact the performance of the model.
-2. **Overfitting**: Large language models can be prone to overfitting, especially when fine-tuned for specific tasks.
-3. **Interpretability**: The complex internal workings of large language models can make it challenging to interpret the results and understand the decision-making process.
+P(A|B) = P(A ∩ B) / P(B)
 
 **Conclusion**
 
-Text classification is a fundamental task in NLP that has numerous applications in various domains. The use of large language models has revolutionized the field by providing powerful tools for feature extraction and model training. However, it is essential to address the challenges and limitations associated with these models to ensure their effective deployment in real-world applications.
+In this chapter, we have covered the fundamental concepts of linear algebra, calculus, and probability theory that are essential for understanding the underlying principles of language models. These mathematical concepts and techniques form the foundation of many machine learning and natural language processing techniques and are used extensively in the development of language models.
 
-### Named Entity Recognition
-**Named Entity Recognition: Explanation of Named Entity Recognition using Large Language Models**
+## Chapter 4: Language Model Architectures
+**Chapter 4: Language Model Architectures**
 
-Named Entity Recognition (NER) is a fundamental task in Natural Language Processing (NLP) that involves identifying and categorizing named entities in unstructured text into predefined categories such as person, organization, location, date, time, etc. The goal of NER is to automatically identify and classify named entities in text, which is crucial for various applications such as information retrieval, question answering, and text summarization.
+Language models are a crucial component of natural language processing (NLP) systems, enabling machines to understand and generate human-like language. In this chapter, we will delve into the world of language model architectures, exploring the evolution of these models and the key components that make them tick. We will examine three prominent architectures: Recurrent Neural Networks (RNNs), Convolutional Neural Networks (CNNs), and Transformers.
 
-**Introduction to Named Entity Recognition**
+**4.1 Introduction to Language Models**
 
-Named Entity Recognition is a sub-task of Information Extraction, which is a key component of NLP. The task of NER involves identifying and categorizing named entities in unstructured text into predefined categories. The categories of named entities include:
+Language models are designed to predict the probability of a sequence of words given the context. They are trained on vast amounts of text data, learning to recognize patterns, relationships, and nuances of language. The primary goal of a language model is to generate coherent and meaningful text, whether it's a sentence, paragraph, or even an entire document.
 
-* Person: refers to individuals, such as names, titles, and occupations
-* Organization: refers to companies, institutions, and organizations
-* Location: refers to geographical locations, such as cities, countries, and regions
-* Date: refers to dates, times, and durations
-* Time: refers to times, schedules, and durations
-* Event: refers to events, meetings, and activities
+**4.2 Recurrent Neural Networks (RNNs)**
 
-**Large Language Models and Named Entity Recognition**
+Recurrent Neural Networks (RNNs) are a type of neural network designed to handle sequential data, such as text or speech. RNNs are particularly well-suited for language modeling tasks due to their ability to capture long-range dependencies and temporal relationships within a sequence.
 
-Large language models have revolutionized the field of NLP, and NER is no exception. The advent of large language models has enabled the development of more accurate and efficient NER systems. Large language models are trained on massive amounts of text data, which allows them to learn complex patterns and relationships between words.
+**Key Components:**
 
-The use of large language models for NER has several advantages:
+1. **Recurrent Cells:** The core component of an RNN is the recurrent cell, which processes the input sequence one step at a time. The cell maintains a hidden state, which captures the contextual information from previous steps.
+2. **Hidden State:** The hidden state is an internal representation of the input sequence, allowing the RNN to capture long-term dependencies and relationships.
+3. **Activation Functions:** RNNs employ activation functions, such as sigmoid or tanh, to introduce non-linearity and enable the network to learn complex patterns.
 
-* Improved accuracy: Large language models can learn to recognize patterns and relationships between words, which enables them to identify named entities more accurately.
-* Increased efficiency: Large language models can process text quickly and efficiently, making them suitable for large-scale NER applications.
-* Flexibility: Large language models can be fine-tuned for specific NER tasks and domains, making them adaptable to different applications.
+**Advantages:**
 
-**How Large Language Models Work for NER**
+1. **Captures Long-Range Dependencies:** RNNs are capable of capturing long-range dependencies, making them suitable for tasks like language modeling and machine translation.
+2. **Handles Variable-Length Sequences:** RNNs can handle sequences of varying lengths, making them versatile for tasks like text classification and sentiment analysis.
 
-Large language models for NER typically involve the following steps:
+**Disadvantages:**
 
-1. **Pre-training**: The large language model is pre-trained on a large corpus of text data to learn general language patterns and relationships.
-2. **Fine-tuning**: The pre-trained model is fine-tuned on a specific NER task and dataset to adapt to the specific task and domain.
-3. **Tokenization**: The input text is tokenized into individual words or subwords.
-4. **Embedding**: The tokenized text is embedded into a high-dimensional vector space using the pre-trained model's weights.
-5. **Classification**: The embedded text is passed through a classification layer to predict the named entity category.
-6. **Post-processing**: The predicted named entities are post-processed to merge overlapping entities and resolve ambiguities.
+1. **Vanishing Gradients:** RNNs suffer from vanishing gradients, where the gradients become increasingly small as they propagate through the network, making it challenging to train deep RNNs.
+2. **Slow Training:** RNNs are computationally expensive and require significant computational resources, making training slow and resource-intensive.
 
-**Challenges and Limitations of NER using Large Language Models**
+**4.3 Convolutional Neural Networks (CNNs)**
 
-While large language models have revolutionized NER, there are still several challenges and limitations to consider:
+Convolutional Neural Networks (CNNs) are primarily designed for image and signal processing tasks. However, researchers have adapted CNNs for language modeling tasks, leveraging their ability to capture local patterns and relationships.
 
-* **Domain adaptation**: Large language models may not generalize well to new domains or tasks, requiring additional fine-tuning.
-* **Ambiguity and ambiguity**: Named entities may be ambiguous or have multiple interpretations, requiring additional processing to resolve ambiguities.
-* **Out-of-vocabulary words**: Large language models may not recognize out-of-vocabulary words or words with rare frequencies.
-* **Scalability**: Large language models can be computationally expensive and require significant computational resources.
+**Key Components:**
 
-**Conclusion**
+1. **Convolutional Layers:** CNNs employ convolutional layers to scan the input sequence, extracting local patterns and features.
+2. **Pooling Layers:** Pooling layers reduce the spatial dimensions of the feature maps, reducing the number of parameters and computation required.
+3. **Activation Functions:** CNNs use activation functions like ReLU or tanh to introduce non-linearity and enable the network to learn complex patterns.
 
-Named Entity Recognition is a fundamental task in NLP that involves identifying and categorizing named entities in unstructured text. The use of large language models has revolutionized NER, enabling more accurate and efficient recognition of named entities. While there are still challenges and limitations to consider, large language models have the potential to significantly improve the accuracy and efficiency of NER systems. As the field of NLP continues to evolve, the use of large language models for NER is likely to play an increasingly important role in various applications.
+**Advantages:**
 
-### Multimodal Language Models
-**Multimodal Language Models: Explanation of Multimodal Language Models**
+1. **Captures Local Patterns:** CNNs are well-suited for capturing local patterns and relationships within a sequence.
+2. **Efficient Computation:** CNNs are computationally efficient, making them suitable for large-scale language modeling tasks.
 
-In recent years, the field of natural language processing (NLP) has witnessed a significant surge in the development of multimodal language models. These models have the ability to process and analyze various forms of data, including text, images, audio, and video. In this chapter, we will delve into the concept of multimodal language models, exploring their definition, types, applications, and challenges.
+**Disadvantages:**
 
-**Definition of Multimodal Language Models**
+1. **Limited Contextual Understanding:** CNNs struggle to capture long-range dependencies and contextual relationships, making them less effective for tasks like language modeling and machine translation.
+2. **Requires Padding:** CNNs require padding to handle variable-length sequences, which can lead to inefficient computation and memory usage.
 
-Multimodal language models are artificial intelligence (AI) systems that are designed to process and analyze multiple forms of data simultaneously. These models are capable of integrating information from various modalities, such as text, images, audio, and video, to generate a comprehensive understanding of the input data. Multimodal language models are often used in applications such as image captioning, visual question answering, and multimodal machine translation.
+**4.4 Transformers**
 
-**Types of Multimodal Language Models**
+Transformers are a relatively recent development in the field of NLP, revolutionizing the way we approach language modeling tasks. Introduced in 2017, Transformers have become the de facto standard for many NLP tasks, including machine translation, text classification, and language modeling.
 
-There are several types of multimodal language models, each with its own strengths and weaknesses. Some of the most common types of multimodal language models include:
+**Key Components:**
 
-1. **Early Fusion Models**: These models combine the input data from multiple modalities at the early stages of processing, often using a simple concatenation or concatenation-based approach.
-2. **Late Fusion Models**: These models process the input data from multiple modalities separately and then combine the outputs at a later stage, often using a weighted average or a voting-based approach.
-3. **Hybrid Models**: These models combine the strengths of early and late fusion models by processing the input data from multiple modalities separately and then combining the outputs using a fusion approach.
-4. **Multimodal Embeddings**: These models represent the input data from multiple modalities as a single vector, often using a neural network-based approach.
+1. **Self-Attention Mechanism:** The Transformer's core component is the self-attention mechanism, which allows the model to attend to specific parts of the input sequence and weigh their importance.
+2. **Encoder-Decoder Architecture:** The Transformer employs an encoder-decoder architecture, where the encoder processes the input sequence and the decoder generates the output sequence.
+3. **Positional Encoding:** The Transformer uses positional encoding to capture the sequential nature of the input sequence, allowing the model to understand the context and relationships between words.
 
-**Applications of Multimodal Language Models**
+**Advantages:**
 
-Multimodal language models have a wide range of applications in various fields, including:
+1. **Captures Long-Range Dependencies:** Transformers are capable of capturing long-range dependencies and contextual relationships, making them suitable for tasks like machine translation and language modeling.
+2. **Parallelization:** Transformers can be parallelized, making them computationally efficient and scalable for large-scale language modeling tasks.
 
-1. **Image Captioning**: Multimodal language models can be used to generate captions for images, allowing for more accurate and descriptive captions.
-2. **Visual Question Answering**: Multimodal language models can be used to answer questions about images, allowing for more accurate and informative answers.
-3. **Multimodal Machine Translation**: Multimodal language models can be used to translate text and images, allowing for more accurate and informative translations.
-4. **Multimodal Sentiment Analysis**: Multimodal language models can be used to analyze the sentiment of text and images, allowing for more accurate and informative sentiment analysis.
+**Disadvantages:**
 
-**Challenges of Multimodal Language Models**
-
-Despite the many benefits of multimodal language models, there are several challenges that need to be addressed:
-
-1. **Data Quality**: Multimodal language models require high-quality data from multiple modalities, which can be difficult to obtain and process.
-2. **Modalities**: Multimodal language models require the integration of multiple modalities, which can be challenging due to differences in data formats and processing requirements.
-3. **Evaluation Metrics**: Multimodal language models require the development of new evaluation metrics that can accurately assess the performance of these models.
-4. **Interpretability**: Multimodal language models require the development of methods to interpret the results of these models, allowing for a better understanding of the decision-making process.
+1. **Computational Complexity:** Transformers require significant computational resources, making them challenging to train on large datasets.
+2. **Overfitting:** Transformers are prone to overfitting, particularly when dealing with small datasets or limited training data.
 
 **Conclusion**
 
-Multimodal language models have the potential to revolutionize the field of NLP by enabling the integration of multiple forms of data. However, there are several challenges that need to be addressed, including data quality, modalities, evaluation metrics, and interpretability. By overcoming these challenges, multimodal language models can be used to improve the accuracy and informativeness of various applications, including image captioning, visual question answering, and multimodal machine translation.
+In this chapter, we have explored the evolution of language model architectures, from Recurrent Neural Networks (RNNs) to Convolutional Neural Networks (CNNs) and finally, the Transformer. Each architecture has its strengths and weaknesses, and understanding these limitations is crucial for selecting the most suitable architecture for a specific task. As the field of NLP continues to evolve, we can expect to see new and innovative architectures emerge, further pushing the boundaries of what is possible in language modeling and beyond.
 
-### Explainability and Interpretability
-**Explainability and Interpretability: Overview of Explainability and Interpretability Techniques for Large Language Models**
+## Chapter 5: Word Embeddings
+**Chapter 5: Word Embeddings: Word2Vec, GloVe, and other word embedding techniques**
 
-As the use of large language models (LLMs) becomes increasingly widespread, there is a growing need to understand how these models make predictions and decisions. This is particularly important in high-stakes applications such as healthcare, finance, and law, where the accuracy and reliability of LLMs can have significant consequences. In this chapter, we will explore the concepts of explainability and interpretability, and provide an overview of the various techniques used to achieve these goals.
+Word embeddings are a fundamental concept in natural language processing (NLP) and have revolutionized the field of artificial intelligence (AI) in recent years. Word embeddings are a way to represent words as vectors in a high-dimensional space, where semantically similar words are mapped to nearby points in the space. This chapter will delve into the world of word embeddings, exploring the most popular techniques, including Word2Vec and GloVe, as well as other notable approaches.
 
-**What is Explainability?**
+**5.1 Introduction to Word Embeddings**
 
-Explainability refers to the ability to provide insights into the inner workings of a model, allowing users to understand how it makes predictions and decisions. This is particularly important in applications where the model's decisions have significant consequences, such as in healthcare or finance. Explainability is often achieved through the use of techniques that provide insights into the model's internal workings, such as feature importance or attention mechanisms.
+Word embeddings are a method of representing words as vectors in a high-dimensional space. This representation allows words with similar meanings or contexts to be mapped to nearby points in the space. The idea behind word embeddings is that words with similar meanings or contexts should be close together in the vector space, making it easier to perform tasks such as text classification, sentiment analysis, and language translation.
 
-**What is Interpretability?**
+**5.2 Word2Vec: A Brief Overview**
 
-Interpretability is closely related to explainability, but focuses more on the ability to understand the model's behavior and decision-making process. Interpretability is often achieved through the use of techniques that provide insights into the model's internal workings, such as feature importance or attention mechanisms. Interpretability is particularly important in applications where the model's decisions have significant consequences, such as in healthcare or finance.
+Word2Vec is a popular word embedding technique developed by Mikolov et al. in 2013. It uses a two-layer neural network to predict the context words given a target word and vice versa. The model is trained on a large corpus of text and the resulting word vectors are used for a variety of NLP tasks.
+
+**5.3 Word2Vec Architecture**
+
+The Word2Vec architecture consists of two main components: the input layer and the output layer. The input layer is a vector representation of the input word, while the output layer is a vector representation of the context words. The model is trained using a combination of two tasks: predicting the context words given the target word and predicting the target word given the context words.
+
+**5.4 Word2Vec Training**
+
+Word2Vec training involves two main steps: building the vocabulary and training the model. The vocabulary is built by tokenizing the input text and removing stop words. The model is then trained using a combination of two tasks: predicting the context words given the target word and predicting the target word given the context words.
+
+**5.5 GloVe: A Brief Overview**
+
+GloVe (Global Vectors for Word Representation) is another popular word embedding technique developed by Pennington et al. in 2014. It uses a matrix factorization technique to learn word vectors from a large corpus of text.
+
+**5.6 GloVe Architecture**
+
+The GloVe architecture consists of a matrix factorization technique that maps words to vectors in a high-dimensional space. The model is trained using a combination of two tasks: predicting the context words given the target word and predicting the target word given the context words.
+
+**5.7 GloVe Training**
+
+GloVe training involves two main steps: building the vocabulary and training the model. The vocabulary is built by tokenizing the input text and removing stop words. The model is then trained using a combination of two tasks: predicting the context words given the target word and predicting the target word given the context words.
+
+**5.8 Other Word Embedding Techniques**
+
+While Word2Vec and GloVe are two of the most popular word embedding techniques, there are many other approaches that have been proposed in recent years. Some notable examples include:
+
+* FastText: A variant of Word2Vec that uses a different architecture and training algorithm.
+* Doc2Vec: A technique that extends Word2Vec to learn vector representations of documents.
+* Skip-Thought Vectors: A technique that uses a combination of Word2Vec and Skip-Thoughts to learn vector representations of sentences.
+
+**5.9 Applications of Word Embeddings**
+
+Word embeddings have a wide range of applications in NLP, including:
+
+* Text classification: Word embeddings can be used to classify text as spam or non-spam.
+* Sentiment analysis: Word embeddings can be used to analyze the sentiment of text.
+* Language translation: Word embeddings can be used to translate text from one language to another.
+* Information retrieval: Word embeddings can be used to retrieve relevant documents from a large corpus of text.
+
+**5.10 Conclusion**
+
+Word embeddings are a powerful tool in the field of NLP, allowing words to be represented as vectors in a high-dimensional space. Word2Vec and GloVe are two of the most popular word embedding techniques, but there are many other approaches that have been proposed in recent years. Word embeddings have a wide range of applications in NLP, including text classification, sentiment analysis, language translation, and information retrieval.
+
+## Chapter 6: Language Model Training
+**Chapter 6: Language Model Training: Training Objectives, Optimization Techniques, and Hyperparameter Tuning**
+
+Language models are a cornerstone of natural language processing (NLP) and have revolutionized the field of artificial intelligence. The training of language models involves a complex interplay of objectives, optimization techniques, and hyperparameters. In this chapter, we will delve into the intricacies of language model training, exploring the various objectives, optimization techniques, and hyperparameter tuning strategies that are essential for building robust and effective language models.
+
+**6.1 Training Objectives**
+
+The primary objective of language model training is to optimize the model's ability to predict the next word in a sequence of text, given the context of the previous words. This is often referred to as the masked language modeling (MLM) task. The MLM task involves predicting a randomly selected word in a sentence, while the remaining words are kept intact. The goal is to maximize the likelihood of the predicted word given the context.
+
+However, language models can be trained for various objectives, including:
+
+1. **Masked Language Modeling (MLM)**: As mentioned earlier, the MLM task involves predicting a randomly selected word in a sentence, while the remaining words are kept intact.
+2. **Next Sentence Prediction (NSP)**: This task involves predicting whether two sentences are adjacent in the original text or not.
+3. **Sentiment Analysis**: This task involves predicting the sentiment of a given text, which can be classified as positive, negative, or neutral.
+4. **Named Entity Recognition (NER)**: This task involves identifying and categorizing named entities in unstructured text into predefined categories such as person, organization, location, etc.
+
+**6.2 Optimization Techniques**
+
+Optimization techniques play a crucial role in language model training, as they determine the direction and speed of the optimization process. The most commonly used optimization techniques in language model training are:
+
+1. **Stochastic Gradient Descent (SGD)**: SGD is a popular optimization technique that updates the model parameters in the direction of the negative gradient of the loss function.
+2. **Adam**: Adam is a variant of SGD that adapts the learning rate for each parameter based on the magnitude of the gradient.
+3. **Adagrad**: Adagrad is another variant of SGD that adjusts the learning rate for each parameter based on the magnitude of the gradient.
+4. **RMSProp**: RMSProp is an optimization algorithm that divides the learning rate by an exponentially decaying average of squared gradients.
+
+**6.3 Hyperparameter Tuning**
+
+Hyperparameter tuning is a critical step in language model training, as it involves selecting the optimal values for the model's hyperparameters. The most commonly tuned hyperparameters in language model training are:
+
+1. **Batch Size**: The batch size determines the number of training examples used to update the model parameters in each iteration.
+2. **Learning Rate**: The learning rate determines the step size of the model parameters in each iteration.
+3. **Number of Layers**: The number of layers determines the depth of the neural network.
+4. **Embedding Dimension**: The embedding dimension determines the size of the word embeddings.
+5. **Hidden State Size**: The hidden state size determines the size of the hidden state in the recurrent neural network (RNN) or long short-term memory (LSTM) network.
+
+**6.4 Hyperparameter Tuning Strategies**
+
+There are several strategies for hyperparameter tuning, including:
+
+1. **Grid Search**: Grid search involves evaluating the model on a grid of hyperparameter combinations and selecting the combination that yields the best performance.
+2. **Random Search**: Random search involves randomly sampling hyperparameter combinations and evaluating the model on each combination.
+3. **Bayesian Optimization**: Bayesian optimization involves using a probabilistic model to search for the optimal hyperparameter combination.
+4. **Hyperband**: Hyperband is a Bayesian optimization algorithm that uses a probabilistic model to search for the optimal hyperparameter combination.
+
+**6.5 Conclusion**
+
+In this chapter, we have explored the intricacies of language model training, including the various objectives, optimization techniques, and hyperparameter tuning strategies. We have also discussed the importance of hyperparameter tuning and the various strategies for tuning hyperparameters. By understanding the complex interplay of objectives, optimization techniques, and hyperparameters, we can build robust and effective language models that can be applied to a wide range of NLP tasks.
+
+## Chapter 7: Transformer Models
+**Chapter 7: Transformer Models: In-depth look at Transformer architecture, BERT, and its variants**
+
+The Transformer model, introduced in 2017 by Vaswani et al. in the paper "Attention Is All You Need," revolutionized the field of natural language processing (NLP) by providing a new paradigm for sequence-to-sequence tasks. The Transformer architecture has since been widely adopted in various NLP applications, including machine translation, text classification, and question answering. This chapter delves into the Transformer architecture, its variants, and its applications, with a focus on BERT, a popular variant of the Transformer model.
+
+**7.1 Introduction to the Transformer Architecture**
+
+The Transformer model is a neural network architecture designed specifically for sequence-to-sequence tasks, such as machine translation and text summarization. The Transformer model is based on self-attention mechanisms, which allow the model to focus on specific parts of the input sequence while processing it. This approach eliminates the need for recurrent neural networks (RNNs) and their associated limitations, such as the vanishing gradient problem.
+
+The Transformer architecture consists of an encoder and a decoder. The encoder takes in a sequence of tokens as input and generates a continuous representation of the input sequence. The decoder then generates the output sequence, one token at a time, based on the encoder's output and the previous tokens generated.
+
+**7.2 Self-Attention Mechanisms**
+
+Self-attention mechanisms are the core component of the Transformer architecture. Self-attention allows the model to focus on specific parts of the input sequence while processing it. This is achieved by computing the attention weights, which represent the importance of each input token with respect to the current token being processed.
+
+The self-attention mechanism is computed using three linear transformations: query (Q), key (K), and value (V). The query and key vectors are used to compute the attention weights, while the value vector is used to compute the output. The attention weights are computed using the dot product of the query and key vectors, followed by a softmax function.
+
+**7.3 BERT: A Pre-trained Language Model**
+
+BERT (Bidirectional Encoder Representations from Transformers) is a pre-trained language model developed by Google in 2018. BERT is based on the Transformer architecture and is trained on a large corpus of text, such as the entire Wikipedia and BookCorpus. The pre-training objective is to predict the missing word in a sentence, given the context.
+
+BERT's pre-training objective is to predict the missing word in a sentence, given the context. This is achieved by masking a random subset of the tokens in the input sequence and training the model to predict the missing tokens. This process is repeated multiple times, with different subsets of tokens being masked each time.
+
+BERT's pre-training objective is to predict the missing word in a sentence, given the context. This is achieved by masking a random subset of the tokens in the input sequence and training the model to predict the missing tokens. This process is repeated multiple times, with different subsets of tokens being masked each time.
+
+**7.4 Applications of BERT**
+
+BERT has been widely adopted in various NLP applications, including:
+
+1. **Question Answering:** BERT has been used to improve question answering systems by leveraging its ability to understand the context of a sentence.
+2. **Text Classification:** BERT has been used to improve text classification tasks, such as sentiment analysis and spam detection.
+3. **Named Entity Recognition:** BERT has been used to improve named entity recognition tasks, such as identifying the names of people, organizations, and locations.
+4. **Machine Translation:** BERT has been used to improve machine translation tasks, such as translating text from one language to another.
+
+**7.5 Variants of BERT**
+
+Several variants of BERT have been developed, including:
+
+1. **RoBERTa:** RoBERTa is a variant of BERT that uses a different pre-training objective and achieves state-of-the-art results on several NLP tasks.
+2. **DistilBERT:** DistilBERT is a smaller and more efficient variant of BERT that is designed for deployment on mobile devices.
+3. **Longformer:** Longformer is a variant of BERT that is designed for long-range dependencies and is used for tasks such as text classification and sentiment analysis.
+
+**7.6 Conclusion**
+
+In conclusion, the Transformer model and its variants, such as BERT, have revolutionized the field of NLP by providing a new paradigm for sequence-to-sequence tasks. The Transformer architecture's ability to focus on specific parts of the input sequence while processing it has made it a popular choice for various NLP applications. The variants of BERT, such as RoBERTa and DistilBERT, have further improved the performance of the model and expanded its applications to various NLP tasks.
+
+## Chapter 8: Large Language Models
+**Chapter 8: Large Language Models: Scaling Language Models, Model Parallelism, and Distributed Training**
+
+As the field of natural language processing (NLP) continues to evolve, large language models have become increasingly important in various applications, including language translation, text summarization, and chatbots. However, training these models requires significant computational resources and time. In this chapter, we will explore the challenges of scaling language models, the concept of model parallelism, and the techniques used for distributed training.
+
+**8.1 Introduction to Large Language Models**
+
+Large language models are neural networks designed to process and analyze large amounts of text data. These models are typically trained on massive datasets, such as the entire Wikipedia or the entire internet, to learn patterns and relationships between words and phrases. The goal of these models is to generate coherent and meaningful text, often referred to as "language understanding" or "language generation."
+
+**8.2 Challenges of Scaling Language Models**
+
+As language models grow in size and complexity, training them becomes increasingly challenging. Some of the key challenges include:
+
+1. **Computational Resources**: Training large language models requires significant computational resources, including powerful GPUs, TPUs, or cloud-based infrastructure. This can be a major barrier for researchers and developers who do not have access to such resources.
+2. **Data Size and Complexity**: Large language models require massive datasets to learn from, which can be difficult to collect, preprocess, and store.
+3. **Model Complexity**: As models grow in size and complexity, they become more prone to overfitting, requiring careful regularization techniques to prevent overfitting.
+4. **Training Time**: Training large language models can take weeks or even months, making it essential to optimize the training process.
+
+**8.3 Model Parallelism**
+
+Model parallelism is a technique used to scale up the training of large language models by dividing the model into smaller parts and training them in parallel. This approach allows researchers to leverage multiple GPUs, TPUs, or even cloud-based infrastructure to accelerate the training process.
+
+**Types of Model Parallelism**
+
+1. **Data Parallelism**: Divide the model into smaller parts and train each part on a separate GPU or device.
+2. **Model Parallelism**: Divide the model into smaller parts and train each part on a separate GPU or device, while sharing the weights between devices.
+3. **Hybrid Parallelism**: Combine data parallelism and model parallelism to achieve optimal performance.
+
+**8.4 Distributed Training**
+
+Distributed training is a technique used to scale up the training of large language models by distributing the training process across multiple devices or machines. This approach allows researchers to leverage multiple GPUs, TPUs, or even cloud-based infrastructure to accelerate the training process.
+
+**Types of Distributed Training**
+
+1. **Synchronous Distributed Training**: All devices or machines update their weights simultaneously, ensuring that the model converges to a single optimal solution.
+2. **Asynchronous Distributed Training**: Devices or machines update their weights independently, without waiting for other devices to finish their updates.
+
+**8.5 Optimizations for Distributed Training**
+
+To optimize the training process, researchers have developed various techniques, including:
+
+1. **Gradient Accumulation**: Accumulate gradients across multiple devices or machines before updating the model.
+2. **Gradient Synchronization**: Synchronize gradients across devices or machines to ensure consistency.
+3. **Model Averaging**: Average the model weights across devices or machines to ensure convergence.
+
+**8.6 Conclusion**
+
+In this chapter, we explored the challenges of scaling language models, the concept of model parallelism, and the techniques used for distributed training. By leveraging model parallelism and distributed training, researchers can accelerate the training process and achieve optimal performance. As the field of NLP continues to evolve, the development of large language models will play a crucial role in various applications, from language translation to text summarization and chatbots.
+
+**References**
+
+* [1] Vaswani et al. (2017). Attention Is All You Need. In Proceedings of the 31st International Conference on Machine Learning, 3-13.
+* [2] Kingma et al. (2014). Adam: A Method for Stochastic Optimization. In Proceedings of the 31st International Conference on Machine Learning, 3-13.
+* [3] Chen et al. (2016). Distributed Training of Deep Neural Networks. In Proceedings of the 30th International Conference on Machine Learning, 3-13.
+
+**Exercises**
+
+1. Implement a simple language model using a neural network framework such as TensorFlow or PyTorch.
+2. Experiment with different model parallelism techniques to optimize the training process.
+3. Implement a distributed training algorithm using a framework such as TensorFlow or PyTorch.
+
+By completing these exercises, you will gain hands-on experience with large language models, model parallelism, and distributed training, preparing you for more advanced topics in NLP.
+
+## Chapter 9: Multitask Learning and Transfer Learning
+**Chapter 9: Multitask Learning and Transfer Learning: Using Pre-Trained Language Models for Downstream NLP Tasks**
+
+In the previous chapters, we have explored the fundamental concepts and techniques in natural language processing (NLP). We have learned how to process and analyze text data using various algorithms and models. However, in many real-world applications, we often encounter complex tasks that require integrating multiple NLP techniques and leveraging domain-specific knowledge. In this chapter, we will delve into the world of multitask learning and transfer learning, which enables us to utilize pre-trained language models for downstream NLP tasks.
+
+**9.1 Introduction to Multitask Learning**
+
+Multitask learning is a powerful technique that allows us to train a single model to perform multiple tasks simultaneously. This approach has gained significant attention in recent years, particularly in the field of NLP. By training a single model to perform multiple tasks, we can leverage the shared knowledge and features across tasks, leading to improved performance and efficiency.
+
+In the context of NLP, multitask learning has been applied to a wide range of tasks, including language modeling, sentiment analysis, named entity recognition, and machine translation. By training a single model to perform multiple tasks, we can:
+
+1. **Share knowledge**: Multitask learning enables the model to share knowledge and features across tasks, leading to improved performance and efficiency.
+2. **Reduce overfitting**: By training a single model to perform multiple tasks, we can reduce overfitting and improve the model's generalizability.
+3. **Improve robustness**: Multitask learning can improve the model's robustness to noise and outliers by leveraging the shared knowledge and features across tasks.
+
+**9.2 Introduction to Transfer Learning**
+
+Transfer learning is a technique that enables us to leverage pre-trained models and fine-tune them for specific downstream tasks. In the context of NLP, transfer learning has revolutionized the field by enabling us to utilize pre-trained language models for a wide range of downstream tasks.
+
+Transfer learning is based on the idea that a pre-trained model can learn general features and knowledge that are applicable to multiple tasks. By fine-tuning the pre-trained model for a specific downstream task, we can adapt the model to the new task and leverage the shared knowledge and features.
+
+**9.3 Pre-Trained Language Models**
+
+Pre-trained language models have become a cornerstone of NLP research in recent years. These models are trained on large datasets and are designed to learn general features and knowledge that are applicable to multiple tasks. Some of the most popular pre-trained language models include:
+
+1. **BERT (Bidirectional Encoder Representations from Transformers)**: BERT is a pre-trained language model that uses a multi-layer bidirectional transformer encoder to learn general features and knowledge from a large corpus of text.
+2. **RoBERTa (Robustly Optimized BERT Pretraining Approach)**: RoBERTa is a variant of BERT that uses a different pre-training approach and has achieved state-of-the-art results on a wide range of NLP tasks.
+3. **DistilBERT**: DistilBERT is a smaller and more efficient version of BERT that is designed for deployment on mobile devices and other resource-constrained environments.
+
+**9.4 Fine-Tuning Pre-Trained Language Models**
+
+Fine-tuning pre-trained language models is a crucial step in leveraging their capabilities for downstream NLP tasks. Fine-tuning involves adapting the pre-trained model to the specific task and dataset by adjusting the model's weights and learning rate.
+
+Fine-tuning pre-trained language models can be done using various techniques, including:
+
+1. **Task-specific layers**: Adding task-specific layers on top of the pre-trained model to adapt it to the specific task.
+2. **Task-specific objectives**: Using task-specific objectives, such as classification or regression, to adapt the pre-trained model to the specific task.
+3. **Transfer learning**: Fine-tuning the pre-trained model using a small amount of labeled data from the target task.
+
+**9.5 Applications of Multitask Learning and Transfer Learning**
+
+Multitask learning and transfer learning have been applied to a wide range of NLP tasks, including:
+
+1. **Sentiment analysis**: Using multitask learning to perform sentiment analysis on social media posts and product reviews.
+2. **Named entity recognition**: Using transfer learning to fine-tune pre-trained language models for named entity recognition in various domains.
+3. **Machine translation**: Using multitask learning to perform machine translation and other language-related tasks.
+
+**9.6 Challenges and Limitations**
+
+While multitask learning and transfer learning have revolutionized the field of NLP, there are several challenges and limitations that need to be addressed:
+
+1. **Overfitting**: Fine-tuning pre-trained models can lead to overfitting, especially when working with small datasets.
+2. **Data quality**: The quality of the training data is critical in multitask learning and transfer learning.
+3. **Task complexity**: The complexity of the tasks being performed can impact the performance of multitask learning and transfer learning.
+
+**9.7 Conclusion**
+
+In this chapter, we have explored the concepts of multitask learning and transfer learning, which enable us to utilize pre-trained language models for downstream NLP tasks. We have discussed the benefits and challenges of these techniques and explored their applications in various NLP tasks. By leveraging pre-trained language models and fine-tuning them for specific tasks, we can improve the performance and efficiency of our NLP models.
+
+## Chapter 10: Text Classification and Sentiment Analysis
+**Chapter 10: Text Classification and Sentiment Analysis: Using Language Models for Text Classification and Sentiment Analysis**
+
+Text classification and sentiment analysis are two fundamental tasks in natural language processing (NLP) that involve analyzing and categorizing text into predefined categories or determining the emotional tone or sentiment expressed in the text. In this chapter, we will explore the concepts, techniques, and applications of text classification and sentiment analysis, as well as the role of language models in these tasks.
+
+**10.1 Introduction to Text Classification**
+
+Text classification is the process of assigning predefined categories or labels to text data based on its content. This task is crucial in various applications, such as spam filtering, sentiment analysis, and information retrieval. Text classification can be categorized into two main types:
+
+1. **Supervised learning**: In this approach, a labeled dataset is used to train a model, which is then used to classify new, unseen text data.
+2. **Unsupervised learning**: In this approach, no labeled dataset is used, and the model is trained solely on the text data itself.
+
+**10.2 Text Classification Techniques**
+
+Several techniques are employed in text classification, including:
+
+1. **Bag-of-words (BoW)**: This method represents text as a bag of words, where each word is weighted based on its frequency or importance.
+2. **Term Frequency-Inverse Document Frequency (TF-IDF)**: This method extends the BoW approach by incorporating the importance of each word in the entire corpus.
+3. **N-grams**: This method represents text as a sequence of N-grams, where N is a predefined value.
+4. **Deep learning-based approaches**: These approaches use neural networks to learn complex patterns in text data.
+
+**10.3 Sentiment Analysis**
+
+Sentiment analysis is the process of determining the emotional tone or sentiment expressed in text data. This task is crucial in various applications, such as customer feedback analysis, opinion mining, and market research. Sentiment analysis can be categorized into two main types:
+
+1. **Sentiment classification**: This approach classifies text as positive, negative, or neutral.
+2. **Sentiment intensity analysis**: This approach quantifies the intensity of the sentiment expressed in the text.
+
+**10.4 Language Models for Text Classification and Sentiment Analysis**
+
+Language models play a crucial role in text classification and sentiment analysis. These models are trained on large datasets and can be fine-tuned for specific tasks. Some popular language models include:
+
+1. **Word2Vec**: This model represents words as vectors in a high-dimensional space, allowing for semantic relationships to be captured.
+2. **BERT**: This model uses a multi-layer perceptron to predict the next word in a sequence, allowing for contextualized representations of words.
+3. **RoBERTa**: This model is a variant of BERT that uses a different architecture and achieves state-of-the-art results in many NLP tasks.
+
+**10.5 Applications of Text Classification and Sentiment Analysis**
+
+Text classification and sentiment analysis have numerous applications in various domains, including:
+
+1. **Customer feedback analysis**: Sentiment analysis can be used to analyze customer feedback and sentiment towards a product or service.
+2. **Market research**: Sentiment analysis can be used to analyze market trends and sentiment towards a particular brand or product.
+3. **Social media monitoring**: Text classification and sentiment analysis can be used to monitor social media conversations and sentiment towards a particular brand or topic.
+4. **Healthcare**: Text classification and sentiment analysis can be used to analyze patient feedback and sentiment towards healthcare services.
+
+**10.6 Challenges and Future Directions**
+
+Despite the progress made in text classification and sentiment analysis, several challenges remain, including:
+
+1. **Handling out-of-vocabulary words**: Dealing with words that are not present in the training data.
+2. **Handling ambiguity and ambiguity**: Dealing with ambiguous or ambiguous text.
+3. **Scalability**: Scaling text classification and sentiment analysis to large datasets.
+
+In conclusion, text classification and sentiment analysis are crucial tasks in NLP that have numerous applications in various domains. Language models play a vital role in these tasks, and future research should focus on addressing the challenges and limitations mentioned above.
+
+## Chapter 11: Language Translation and Summarization
+**Chapter 11: Language Translation and Summarization: Applications of Language Models in Machine Translation and Text Summarization**
+
+Language models have revolutionized the field of natural language processing (NLP) by enabling machines to understand, generate, and translate human language. In this chapter, we will delve into the applications of language models in machine translation and text summarization, two critical areas where language models have made significant impacts.
+
+**11.1 Introduction to Machine Translation**
+
+Machine translation is the process of automatically translating text from one language to another. With the rise of globalization, the need for efficient and accurate machine translation has become increasingly important. Language models have played a crucial role in improving the accuracy and efficiency of machine translation systems.
+
+**11.2 Applications of Language Models in Machine Translation**
+
+Language models have several applications in machine translation:
+
+1. **Neural Machine Translation (NMT)**: NMT is a type of machine translation that uses neural networks to translate text from one language to another. Language models are used to generate the target language output based on the input source language.
+2. **Post-Editing Machine Translation (PEMT)**: PEMT is a hybrid approach that combines the output of an NMT system with human post-editing to improve the quality of the translation.
+3. **Machine Translation Evaluation**: Language models can be used to evaluate the quality of machine translation systems by comparing the output with human-translated texts.
+4. **Translation Memory**: Language models can be used to improve the efficiency of translation memory systems, which store and retrieve previously translated texts.
+
+**11.3 Challenges in Machine Translation**
+
+Despite the progress made in machine translation, there are several challenges that need to be addressed:
+
+1. **Lack of Data**: Machine translation systems require large amounts of training data to learn the patterns and structures of languages.
+2. **Domain Adaptation**: Machine translation systems often struggle to adapt to new domains or topics.
+3. **Idiomatic Expressions**: Idiomatic expressions and figurative language can be challenging for machine translation systems to accurately translate.
+4. **Cultural and Contextual Factors**: Machine translation systems need to be aware of cultural and contextual factors that can affect the meaning of text.
+
+**11.4 Text Summarization**
+
+Text summarization is the process of automatically generating a concise and accurate summary of a large document or text. Language models have made significant progress in text summarization, enabling machines to summarize long documents and articles.
+
+**11.5 Applications of Language Models in Text Summarization**
+
+Language models have several applications in text summarization:
+
+1. **Extractive Summarization**: Language models can be used to extract the most important sentences or phrases from a document to create a summary.
+2. **Abstractive Summarization**: Language models can be used to generate a summary from scratch, rather than simply extracting sentences.
+3. **Summarization Evaluation**: Language models can be used to evaluate the quality of summarization systems by comparing the output with human-generated summaries.
+
+**11.6 Challenges in Text Summarization**
+
+Despite the progress made in text summarization, there are several challenges that need to be addressed:
+
+1. **Lack of Data**: Text summarization systems require large amounts of training data to learn the patterns and structures of language.
+2. **Domain Adaptation**: Text summarization systems often struggle to adapt to new domains or topics.
+3. **Contextual Factors**: Text summarization systems need to be aware of contextual factors that can affect the meaning of text.
+4. **Evaluation Metrics**: Developing accurate evaluation metrics for text summarization systems is an ongoing challenge.
+
+**11.7 Conclusion**
+
+In conclusion, language models have revolutionized the fields of machine translation and text summarization. While there are still challenges to be addressed, the applications of language models in these areas have the potential to transform the way we communicate and access information. As the field continues to evolve, we can expect to see even more innovative applications of language models in machine translation and text summarization.
+
+## Chapter 12: Conversational AI and Dialogue Systems
+**Chapter 12: Conversational AI and Dialogue Systems: Using Language Models for Conversational AI and Dialogue Systems**
+
+Conversational AI and dialogue systems have revolutionized the way humans interact with machines. With the advent of language models, conversational AI has become more sophisticated, enabling machines to understand and respond to human language in a more natural and intuitive way. This chapter delves into the world of conversational AI and dialogue systems, exploring the role of language models in this field and the various applications and challenges that come with it.
+
+**What is Conversational AI and Dialogue Systems?**
+
+Conversational AI refers to the use of artificial intelligence (AI) to simulate human-like conversations with humans. Dialogue systems, on the other hand, are software applications that enable humans to interact with machines using natural language. These systems are designed to understand and respond to human input, often using a combination of natural language processing (NLP) and machine learning algorithms.
+
+**The Role of Language Models in Conversational AI and Dialogue Systems**
+
+Language models play a crucial role in conversational AI and dialogue systems. These models are trained on vast amounts of text data and are designed to predict the next word or token in a sequence of text. In the context of conversational AI and dialogue systems, language models are used to:
+
+1. **Understand Human Input**: Language models are used to analyze and understand human input, such as text or speech, and identify the intent behind the input.
+2. **Generate Responses**: Language models are used to generate responses to human input, often using a combination of context, intent, and available information.
+3. **Improve Conversational Flow**: Language models can be used to improve the conversational flow by predicting the next topic or question to ask the user.
+
+**Applications of Conversational AI and Dialogue Systems**
+
+Conversational AI and dialogue systems have numerous applications across various industries, including:
+
+1. **Virtual Assistants**: Virtual assistants like Siri, Google Assistant, and Alexa use conversational AI and dialogue systems to understand and respond to user queries.
+2. **Customer Service**: Conversational AI and dialogue systems are used in customer service chatbots to provide 24/7 support and answer frequently asked questions.
+3. **Healthcare**: Conversational AI and dialogue systems are used in healthcare to provide patient education, triage, and support.
+4. **Education**: Conversational AI and dialogue systems are used in education to provide personalized learning experiences and support.
+
+**Challenges and Limitations of Conversational AI and Dialogue Systems**
+
+While conversational AI and dialogue systems have made significant progress, there are still several challenges and limitations to consider:
+
+1. **Ambiguity and Context**: Conversational AI and dialogue systems struggle with ambiguity and context, often requiring additional context or clarification.
+2. **Limited Domain Knowledge**: Conversational AI and dialogue systems may not have the same level of domain knowledge as humans, leading to inaccuracies or misunderstandings.
+3. **Cultural and Linguistic Variations**: Conversational AI and dialogue systems may struggle with cultural and linguistic variations, requiring additional training and adaptation.
+
+**Future Directions and Research Directions**
+
+As conversational AI and dialogue systems continue to evolve, there are several future directions and research directions to explore:
+
+1. **Multimodal Interaction**: Developing conversational AI and dialogue systems that can interact with humans using multiple modalities, such as text, speech, and gestures.
+2. **Emotional Intelligence**: Developing conversational AI and dialogue systems that can recognize and respond to human emotions.
+3. **Explainability and Transparency**: Developing conversational AI and dialogue systems that provide explainability and transparency in their decision-making processes.
+
+**Conclusion**
+
+Conversational AI and dialogue systems have revolutionized the way humans interact with machines. Language models play a crucial role in this field, enabling machines to understand and respond to human language in a more natural and intuitive way. While there are still challenges and limitations to consider, the future of conversational AI and dialogue systems holds much promise, with numerous applications across various industries. As research and development continue to advance, we can expect to see even more sophisticated and human-like conversational AI and dialogue systems in the years to come.
+
+## Chapter 13: Explainability and Interpretability
+**Chapter 13: Explainability and Interpretability: Techniques for Explaining and Interpreting Language Model Decisions**
+
+In recent years, language models have made tremendous progress in understanding and generating human language. However, as these models become increasingly complex and powerful, it has become essential to understand how they arrive at their decisions. Explainability and interpretability are crucial aspects of building trust in these models, ensuring their reliability, and identifying potential biases. In this chapter, we will delve into the techniques and methods used to explain and interpret language model decisions, providing insights into the inner workings of these complex systems.
+
+**What is Explainability and Interpretability?**
+
+Explainability and interpretability are two related but distinct concepts:
+
+1. **Explainability**: The ability to provide a clear and concise explanation for a model's prediction or decision-making process. This involves understanding the reasoning behind a model's output and identifying the factors that contributed to it.
+2. **Interpretability**: The ability to understand and interpret the internal workings of a model, including the relationships between input features, the decision-making process, and the output.
+
+**Why is Explainability and Interpretability Important?**
+
+Explainability and interpretability are essential for several reasons:
+
+1. **Trust and Transparency**: Models that can explain their decisions build trust with users and stakeholders, as they provide transparency into the decision-making process.
+2. **Error Detection**: By understanding how a model arrives at its decisions, errors can be identified and corrected, reducing the risk of misclassification or biased outcomes.
+3. **Model Improvement**: Explainability and interpretability enable the identification of areas for improvement, allowing model developers to refine and optimize their models.
+4. **Regulatory Compliance**: In regulated industries, such as finance and healthcare, explainability and interpretability are critical for compliance with regulations and ensuring accountability.
 
 **Techniques for Explainability and Interpretability**
 
-There are several techniques that can be used to achieve explainability and interpretability in LLMs. Some of the most common techniques include:
+Several techniques are used to achieve explainability and interpretability in language models:
 
-1. **Attribution Methods**: Attribution methods involve assigning importance scores to different input features or tokens in the input sequence. This allows users to understand which features or tokens are most important for the model's predictions.
-
-2. **Attention Mechanisms**: Attention mechanisms involve assigning weights to different input features or tokens in the input sequence. This allows users to understand which features or tokens are most important for the model's predictions.
-
-3. **Partial Dependence Plots**: Partial dependence plots involve plotting the relationship between a specific input feature and the model's predictions. This allows users to understand how the model's predictions change as a function of a specific input feature.
-
-4. **SHAP Values**: SHAP (SHapley Additive exPlanations) values involve assigning importance scores to different input features or tokens in the input sequence. This allows users to understand which features or tokens are most important for the model's predictions.
-
-5. **LIME**: LIME (Local Interpretable Model-agnostic Explanations) involves training a simple model to mimic the behavior of the original model. This allows users to understand how the original model makes predictions and decisions.
-
-6. **TreeExplainer**: TreeExplainer involves training a decision tree to mimic the behavior of the original model. This allows users to understand how the original model makes predictions and decisions.
-
-7. **Anchors**: Anchors involve identifying specific input features or tokens that are most important for the model's predictions. This allows users to understand which features or tokens are most important for the model's predictions.
-
-8. **Model-Agnostic Explanations**: Model-agnostic explanations involve using techniques such as SHAP or LIME to explain the behavior of any machine learning model, regardless of its architecture or implementation.
+1. **Partial Dependence Plots**: Visualizations that show the relationship between a specific input feature and the model's output, providing insights into the feature's importance.
+2. **SHAP Values**: A technique that assigns a value to each feature for a specific prediction, indicating its contribution to the outcome.
+3. **LIME (Local Interpretable Model-agnostic Explanations)**: A technique that generates an interpretable model locally around a specific instance, providing insights into the model's decision-making process.
+4. **TreeExplainer**: A technique that uses decision trees to approximate the behavior of a complex model, providing insights into the feature importance and relationships.
+5. **Attention Mechanisms**: Techniques that highlight the most relevant input features or tokens in a sequence, providing insights into the model's focus and decision-making process.
+6. **Model-Agnostic Explanations**: Techniques that provide explanations for a model's predictions without requiring access to the model's internal workings.
+7. **Model-Based Explanations**: Techniques that use the model itself to generate explanations, such as using the model to predict the importance of input features.
 
 **Challenges and Limitations**
 
-While explainability and interpretability techniques can provide valuable insights into the behavior of LLMs, there are several challenges and limitations to consider:
+While explainability and interpretability are essential, there are several challenges and limitations to consider:
 
-1. **Model Complexity**: LLMs are complex models that can be difficult to interpret. This can make it challenging to understand how the model makes predictions and decisions.
-
-2. **Data Quality**: The quality of the training data can have a significant impact on the model's behavior and decision-making process. This can make it challenging to understand how the model makes predictions and decisions.
-
-3. **Model Selection**: The choice of model architecture and hyperparameters can have a significant impact on the model's behavior and decision-making process. This can make it challenging to understand how the model makes predictions and decisions.
-
-4. **Scalability**: Explainability and interpretability techniques can be computationally expensive and may not be scalable to large datasets. This can make it challenging to apply these techniques to large datasets.
-
-5. **Interpretability of Complex Models**: Complex models such as LLMs can be difficult to interpret. This can make it challenging to understand how the model makes predictions and decisions.
+1. **Complexity**: Complex models can be difficult to interpret, making it challenging to understand the decision-making process.
+2. **Noise and Bias**: Noisy or biased data can lead to inaccurate explanations and interpretations.
+3. **Model Complexity**: Overly complex models can be difficult to interpret, making it challenging to understand the decision-making process.
+4. **Data Quality**: Poor data quality can lead to inaccurate explanations and interpretations.
 
 **Conclusion**
 
-Explainability and interpretability are critical components of large language models, particularly in high-stakes applications where the accuracy and reliability of the model's predictions and decisions have significant consequences. By understanding how the model makes predictions and decisions, users can gain valuable insights into the model's behavior and decision-making process. This can help to improve the model's performance, identify biases and errors, and ensure that the model is used in a responsible and ethical manner.
+Explainability and interpretability are crucial aspects of building trust in language models. By understanding how these models arrive at their decisions, we can identify biases, errors, and areas for improvement. Techniques such as partial dependence plots, SHAP values, and LIME provide insights into the model's decision-making process, enabling the development of more transparent and reliable models. As language models continue to evolve and become increasingly complex, it is essential to prioritize explainability and interpretability to ensure the trustworthiness and reliability of these models.
 
-## Summary of Key Takeaways
-**Summary of Key Takeaways: A Comprehensive Review of the Book's Key Concepts and Takeaways**
+## Chapter 14: Adversarial Attacks and Robustness
+**Chapter 14: Adversarial Attacks and Robustness: Adversarial Attacks on Language Models and Robustness Techniques**
 
-In this final chapter, we will summarize the key takeaways from the book, providing a comprehensive review of the concepts and ideas discussed throughout the pages. This summary will serve as a valuable reference for readers, allowing them to revisit and reinforce their understanding of the material.
+Adversarial attacks on language models have become a significant concern in the field of natural language processing (NLP). As language models become increasingly sophisticated, they are being used in a wide range of applications, from language translation to text summarization. However, these models are not immune to attacks, and their vulnerability to adversarial attacks can have significant consequences. In this chapter, we will explore the concept of adversarial attacks on language models, the types of attacks that exist, and the techniques used to defend against them.
 
-**I. The Power of [Book Topic]**
+**What are Adversarial Attacks?**
 
-* The book's central theme is the importance of [book topic] in achieving success and personal growth.
-* The concept of [book topic] is explored in depth, highlighting its impact on various aspects of life, including relationships, career, and overall well-being.
+Adversarial attacks are designed to manipulate the output of a machine learning model by introducing carefully crafted input data. The goal of an attacker is to create an input that causes the model to produce an incorrect or undesirable output. In the context of language models, adversarial attacks can take many forms, including:
 
-**II. The Science Behind [Book Topic]**
+1. **Textual attacks**: An attacker can modify the input text to cause the model to produce an incorrect output. For example, an attacker could add or modify words in a sentence to cause the model to misclassify the sentiment of the text.
+2. **Adversarial examples**: An attacker can create a specific input that causes the model to produce an incorrect output. For example, an attacker could create a sentence that is designed to cause a language model to misclassify the intent of the text.
+3. **Data poisoning**: An attacker can manipulate the training data used to train a language model. This can cause the model to learn incorrect patterns and produce incorrect outputs.
 
-* The book delves into the scientific research and studies that support the benefits of [book topic].
-* The discussion covers the neurological and psychological effects of [book topic] on the brain and behavior.
+**Types of Adversarial Attacks on Language Models**
 
-**III. Overcoming Obstacles and Challenges**
+There are several types of adversarial attacks that can be launched against language models. Some of the most common types of attacks include:
 
-* The book provides practical advice and strategies for overcoming common obstacles and challenges related to [book topic].
-* Real-life examples and case studies illustrate the application of these strategies in real-world scenarios.
+1. **Word substitution**: An attacker can substitute a word in a sentence with a similar-sounding word to cause the model to produce an incorrect output.
+2. **Word insertion**: An attacker can insert a word into a sentence to cause the model to produce an incorrect output.
+3. **Word deletion**: An attacker can delete a word from a sentence to cause the model to produce an incorrect output.
+4. **Semantic manipulation**: An attacker can modify the meaning of a sentence by changing the context or adding additional information to cause the model to produce an incorrect output.
 
-**IV. Building Resilience and Adaptability**
+**Consequences of Adversarial Attacks on Language Models**
 
-* The book emphasizes the importance of building resilience and adaptability in the face of adversity.
-* Techniques and exercises are provided to help readers develop these essential skills.
+Adversarial attacks on language models can have significant consequences. Some of the potential consequences include:
 
-**V. Cultivating Mindfulness and Self-Awareness**
+1. **Loss of trust**: Adversarial attacks can cause users to lose trust in language models and their outputs.
+2. **Financial losses**: Adversarial attacks can cause financial losses by manipulating the output of a language model to make incorrect predictions or recommendations.
+3. **Security risks**: Adversarial attacks can compromise the security of a system by manipulating the output of a language model to gain unauthorized access to sensitive information.
 
-* The book highlights the importance of mindfulness and self-awareness in achieving personal growth and success.
-* Practical tips and exercises are offered to help readers cultivate these qualities.
+**Robustness Techniques for Adversarial Attacks on Language Models**
 
-**VI. Nurturing Positive Relationships**
+To defend against adversarial attacks on language models, several robustness techniques can be used. Some of the most common techniques include:
 
-* The book explores the importance of nurturing positive relationships in achieving personal and professional success.
-* Strategies are provided for building and maintaining strong, supportive relationships.
-
-**VII. Embracing Change and Uncertainty**
-
-* The book discusses the importance of embracing change and uncertainty in life.
-* Practical advice is offered for coping with uncertainty and adapting to change.
-
-**VIII. Conclusion: Putting it All Together**
-
-* A summary of the key takeaways from the book is provided.
-* A call to action is issued, encouraging readers to apply the concepts and ideas discussed throughout the book to their own lives.
-
-**Key Takeaways:**
-
-1. [Key takeaway 1]
-2. [Key takeaway 2]
-3. [Key takeaway 3]
-4. [Key takeaway 4]
-5. [Key takeaway 5]
-
-**Additional Resources:**
-
-* A list of recommended readings, articles, and online resources for further learning and exploration.
-* A glossary of key terms and definitions related to the book's topic.
-
-By summarizing the key concepts and takeaways from the book, this chapter provides a comprehensive review of the material, allowing readers to reinforce their understanding and apply the ideas to their own lives.
-
-## Future Directions
-**Future Directions: Discussion of Future Directions and Potential Applications of Large Language Models**
-
-As large language models continue to evolve and improve, it is essential to consider the potential future directions and applications of these powerful tools. In this chapter, we will explore the possibilities and potential applications of large language models, discussing the future of natural language processing and the impact it may have on various industries and aspects of our lives.
-
-**Advancements in Language Understanding**
-
-One of the most significant areas of focus for future development is the improvement of language understanding. Current large language models are capable of processing and generating human-like text, but they still struggle with nuanced understanding of context, tone, and intent. Future advancements in this area could lead to more accurate and effective language processing, enabling applications such as:
-
-* Enhanced customer service chatbots that can understand and respond to complex customer queries
-* Improved language translation systems that can accurately capture the nuances of human language
-* Advanced language-based recommendation systems that can personalize content and services based on user behavior and preferences
-
-**Applications in Healthcare and Medicine**
-
-Large language models have the potential to revolutionize the healthcare and medical industries. Potential applications include:
-
-* Developing personalized medicine treatment plans based on patient-specific genetic and medical data
-* Creating AI-powered diagnostic tools that can analyze medical records and identify potential health risks
-* Improving patient engagement and education through personalized health information and resources
-* Enhancing clinical decision-making through AI-assisted medical research and analysis
-
-**Applications in Education and Learning**
-
-Large language models can also have a significant impact on the education sector, enabling:
-
-* Personalized learning pathways and adaptive assessments that cater to individual students' learning styles and abilities
-* AI-powered tutoring and feedback systems that provide real-time support and guidance
-* Enhanced language learning and literacy programs that can adapt to students' language proficiency levels
-* Improved accessibility for students with disabilities through AI-powered translation and communication tools
-
-**Applications in Business and Industry**
-
-Large language models can also be applied in various business and industrial settings, including:
-
-* Developing AI-powered customer service chatbots that can handle complex customer inquiries
-* Enhancing supply chain management through AI-assisted inventory management and logistics optimization
-* Improving marketing and advertising strategies through AI-powered sentiment analysis and customer feedback analysis
-* Enhancing cybersecurity through AI-powered threat detection and response systems
-
-**Challenges and Concerns**
-
-While the potential applications of large language models are vast and exciting, there are also significant challenges and concerns that need to be addressed. Some of the key concerns include:
-
-* Bias and fairness: Large language models can perpetuate biases and stereotypes present in the data used to train them
-* Privacy and security: Large language models require access to vast amounts of personal data, raising concerns about privacy and security
-* Job displacement: The automation of certain tasks and jobs through AI-powered language models may displace human workers
-* Ethical considerations: The development and deployment of large language models require careful consideration of ethical implications and potential consequences
+1. **Data augmentation**: Data augmentation involves generating additional training data by applying random transformations to the input data. This can help to improve the robustness of a language model to adversarial attacks.
+2. **Regularization**: Regularization involves adding a penalty term to the loss function to discourage the model from making incorrect predictions. This can help to improve the robustness of a language model to adversarial attacks.
+3. **Adversarial training**: Adversarial training involves training a language model on adversarial examples to improve its robustness to attacks.
+4. **Defensive distillation**: Defensive distillation involves training a student model on the output of a teacher model to improve its robustness to attacks.
+5. **Explainability**: Explainability involves providing insights into the decision-making process of a language model to improve its transparency and accountability.
 
 **Conclusion**
 
-The future of large language models holds immense promise, with potential applications across various industries and aspects of our lives. However, it is essential to acknowledge the challenges and concerns that come with the development and deployment of these powerful tools. By addressing these concerns and prioritizing ethical considerations, we can unlock the full potential of large language models and create a brighter, more efficient, and more personalized future.
+Adversarial attacks on language models are a significant concern in the field of NLP. These attacks can have significant consequences, including loss of trust, financial losses, and security risks. To defend against these attacks, several robustness techniques can be used, including data augmentation, regularization, adversarial training, defensive distillation, and explainability. By understanding the types of attacks that exist and the techniques used to defend against them, we can improve the security and robustness of language models and ensure their continued use in a wide range of applications.
 
-**Future Research Directions**
+**References**
 
-Some potential future research directions for large language models include:
+* [1] Goodfellow, I. J., Shlens, J., & Szegedy, C. (2014). Explaining and Harnessing Adversarial Examples. arXiv preprint arXiv:1412.6572.
+* [2] Papernot, N., McDaniel, P. D., & Wu, X. (2016). Distillation as a Defense to Adversarial Attacks. arXiv preprint arXiv:1605.07277.
+* [3] Kurakin, A., Goodfellow, I. J., & Bengio, S. (2016). Adversarial Examples in the Physical World. arXiv preprint arXiv:1607.05606.
+* [4] Carlini, N., & Wagner, D. (2017). Adversarial Examples for Neural Networks: Big Adversarial Patch Attack. arXiv preprint arXiv:1711.03141.
+* [5] Madry, A., Makel, A., & Raffel, C. (2017). Towards Deep Learning Models Resistant to Adversarial Attacks. arXiv preprint arXiv:1706.09578.
 
-* Developing more accurate and nuanced language understanding capabilities
-* Improving the fairness and bias of large language models
-* Enhancing the security and privacy of large language models
-* Exploring new applications and use cases for large language models
-* Investigating the potential impact of large language models on employment and society
+## Chapter 15: Future Directions and Emerging Trends
+**Chapter 15: Future Directions and Emerging Trends: Emerging Trends and Future Directions in Language Model Research**
 
-By addressing these research directions and concerns, we can ensure that large language models are developed and deployed in a responsible and ethical manner, unlocking their full potential to transform industries and improve our lives.
+As language models continue to advance and become increasingly integrated into various aspects of our lives, it is essential to look ahead and consider the future directions and emerging trends in this field. This chapter will explore the current state of language model research, identify the most promising areas of development, and provide insights into the potential applications and implications of these advancements.
+
+**15.1 Introduction**
+
+Language models have come a long way since their inception, and their impact on various industries and aspects of our lives is undeniable. From chatbots and virtual assistants to language translation and text summarization, language models have revolutionized the way we interact with technology. However, as we continue to push the boundaries of what is possible with language models, it is crucial to consider the future directions and emerging trends in this field.
+
+**15.2 Current State of Language Model Research**
+
+The current state of language model research is characterized by significant advancements in areas such as:
+
+1. **Deep Learning Architectures**: The development of deep learning architectures, such as recurrent neural networks (RNNs) and transformers, has enabled language models to process and generate human-like language.
+2. **Pre-training and Fine-tuning**: The pre-training and fine-tuning of language models have improved their performance and adaptability to specific tasks and domains.
+3. **Multimodal Processing**: The integration of multimodal input and output, such as images, videos, and audio, has expanded the capabilities of language models.
+4. **Explainability and Interpretability**: The development of techniques for explaining and interpreting language model predictions has increased transparency and trust in these models.
+
+**15.3 Emerging Trends and Future Directions**
+
+Several emerging trends and future directions in language model research are likely to shape the field in the coming years:
+
+1. **Explainable AI**: The increasing focus on explainability and interpretability will continue to drive the development of more transparent and accountable language models.
+2. **Multimodal Fusion**: The integration of multimodal input and output will continue to expand the capabilities of language models, enabling more sophisticated interactions with humans.
+3. **Human-Like Language Generation**: The development of language models that can generate human-like language, including nuances and idioms, will continue to improve.
+4. **Real-time Processing**: The increasing demand for real-time processing and response times will drive the development of more efficient and scalable language models.
+5. **Edge Computing**: The growing importance of edge computing will enable language models to be deployed on edge devices, reducing latency and improving responsiveness.
+6. **Adversarial Attacks and Defenses**: The development of adversarial attacks and defenses will become increasingly important as language models become more widespread and critical.
+7. **Human-Machine Collaboration**: The integration of human and machine intelligence will continue to shape the development of language models, enabling more effective and efficient collaboration.
+
+**15.4 Applications and Implications**
+
+The future directions and emerging trends in language model research will have significant implications for various industries and aspects of our lives. Some potential applications and implications include:
+
+1. **Virtual Assistants**: The integration of language models into virtual assistants will enable more sophisticated and personalized interactions.
+2. **Natural Language Processing**: The development of more advanced language models will continue to improve the accuracy and efficiency of natural language processing tasks.
+3. **Language Translation**: The improvement of language translation capabilities will enable more effective communication across languages and cultures.
+4. **Healthcare and Medicine**: The integration of language models into healthcare and medicine will enable more accurate diagnosis and treatment, as well as improved patient outcomes.
+5. **Education and Learning**: The development of more advanced language models will enable more effective and personalized learning experiences.
+
+**15.5 Conclusion**
+
+The future directions and emerging trends in language model research will continue to shape the field and have significant implications for various industries and aspects of our lives. As we look ahead, it is essential to consider the potential applications and implications of these advancements and to continue pushing the boundaries of what is possible with language models.

--- a/main.py
+++ b/main.py
@@ -97,7 +97,7 @@ def generate_book_structure(prompt: str):
             },
             {
                 "role": "user",
-                "content": f"Write a comprehensive structure, omiting common sections like a forward or author's note, for a long (>300 page) book on the following subject:\n\n<subject>{prompt}</subject>"
+                "content": f"Write a comprehensive structure, omiting introduction and conclusion sections (forward, author's note, summary), for a long (>300 page) book on the following subject:\n\n<subject>{prompt}</subject>"
             }
         ],
         temperature=0.3,


### PR DESCRIPTION
New prompting strategy omits generation of general sections that require broader context of the book, such as introduction and conclusion. These sections will be added back in a later feature which generates them after the main book content has been created. This will increase their relevance to the actual text generated.